### PR TITLE
Stop messing with people's charsets

### DIFF
--- a/lib/modem.js
+++ b/lib/modem.js
@@ -66,7 +66,6 @@ Modem.prototype.dial = function(options, callback) {
 
   req.on('response', function(res) {
     if (options.isStream) {
-      res.setEncoding('utf8');
       self.buildPayload(null, options.isStream, options.statusCodes, res, null, callback);
     } else {
       var chunks = '';


### PR DESCRIPTION
TL;DR: Forcing the response's encoding breaks `/attach` when multiplexing is activated.

Long story:

When you `/attach` a container that has `Config.Tty` set to `false`, docker enables multiplexing of the response in order to differenciate `stdin`, `stdout` and `stderr`. Multiplexing consist in a simple enough protocol: 1 byte for the stream type, 3 null bytes, 4 bytes for the content length.

Now here's my understanding of what happens when you force the reponse's encoding to `utf8` (not sure cause I don't really know how node internals work in this regard): node treats the response data as a string and tries to convert it from whatever encoding it thinks it is to `utf8`. In my case, it converted the last byte (`164`) to an unicode triplet (`239`,`191`,`189`). Things get fun when `stream.read(8)` starts returning 10 bytes.

Anyway, this is really annoying, and for a library that claims to "NOT break any stream" quite unfortunate too :-)
