### PR TITLE
Add guard in container.inspect when evaluating a container for console output

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -6,19 +6,23 @@ var Container = function(modem, id) {
 };
 
 Container.prototype.inspect = function(callback) {
-  var opts = {
-    path: '/containers/' + this.id + '/json',
-    method: 'GET',
-    statusCodes: {
-      200: true,
-      404: "no such container",
-      500: "server error"
-    }
-  };
+  if (typeof callback === 'function') {
+    var opts = {
+      path: '/containers/' + this.id + '/json',
+      method: 'GET',
+      statusCodes: {
+        200: true,
+        404: "no such container",
+        500: "server error"
+      }
+    };
 
-  this.modem.dial(opts, function(err, data) {
-    callback(err, data);
-  });
+    this.modem.dial(opts, function(err, data) {
+      callback(err, data);
+    });
+  } else {
+    return JSON.stringify({id: this.id});
+  }
 };
 
 Container.prototype.top = function(opts, callback) {


### PR DESCRIPTION
Fixes https://github.com/apocas/dockerode/issues/12
