### PR TITLE
Use public methods to create containers

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -23,7 +23,7 @@ Docker.prototype.createContainer = function(opts, callback) {
 
   this.modem.dial(opts, function(err, data) {
     if(err) return callback(err, data);
-    callback(err, new Container(self.modem, data.Id));
+    callback(err, self.getContainer(data.Id));
   });
 };
 
@@ -121,7 +121,7 @@ Docker.prototype.listContainers = function(opts, callback) {
 
     var containers = [];
     for (var i = data.length - 1; i >= 0; i--) {
-      containers.push(new Container(self.modem, data[i].Id));
+      containers.push(self.getContainer(data[i].Id));
     }
     callback(err, containers);
   });


### PR DESCRIPTION
The short answer is I want to promisify all the things and this change allows me to overload the public api as a whole so I can do this.

(longer version) Promises are part of JS in the near future http://wiki.ecmascript.org/doku.php?id=strawman:promises
