### PR TITLE
Allow containers to be named

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -10,7 +10,7 @@ var Docker = function(opts) {
 Docker.prototype.createContainer = function(opts, callback) {
   var self = this;
   var opts = {
-    path: '/containers/create',
+    path: '/containers/create?',
     method: 'POST',
     options: opts,
     statusCodes: {

--- a/test/docker.js
+++ b/test/docker.js
@@ -143,13 +143,18 @@ describe("#docker", function() {
         expect(err).to.be.null;
         expect(container).to.be.ok;
 
+        container.inspect(function (err, info) {
+          expect(err).to.be.null;
+          expect(info.Name).to.equal('/test')
+        })
+
         container.remove(function(err, data) {
           expect(err).to.be.null;
           done();
         });
       }
 
-      docker.createContainer({Image: 'ubuntu', Cmd: ['/bin/bash']}, handler);
+      docker.createContainer({Image: 'ubuntu', Cmd: ['/bin/bash'], name: 'test'}, handler);
     });
   });
 


### PR DESCRIPTION
Don't think this is the most elegant way to do this, but it seems to work with no ill effects.

Let me know if there is another way of sending a POST but also with custom query string parameters(so we don't have to send all of the irrelevant params)!
