### PR TITLE
Adding file parameter to Container.copy.

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -239,7 +239,7 @@ Container.prototype.remove = function(callback) {
   });
 };
 
-Container.prototype.copy = function(callback) {
+Container.prototype.copy = function(opts, callback) {
   var opts = {
     path: '/containers/' + this.id + '/copy',
     method: 'POST',
@@ -248,7 +248,8 @@ Container.prototype.copy = function(callback) {
       200: true,
       404: "no such container",
       500: "server error"
-    }
+    },
+    options: opts
   };
 
   this.modem.dial(opts, function(err, data) {


### PR DESCRIPTION
This particular endpoint needs you to tell it what to copy and returns 500 without it.
