### PR TITLE
Use a consistent signature for buildImage()

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -71,6 +71,11 @@ Docker.prototype.checkAuth = function(opts, callback) {
 };
 
 Docker.prototype.buildImage = function(file, opts, callback) {
+  if (!callback && typeof(opts) === 'function') {
+    callback = opts;
+    opts = null;
+  }
+  
   var self = this;
   var opts = {
     path: '/build?',


### PR DESCRIPTION
The other functions allow options to be skipped if they're not in use. buildImage doesn't, until this patch is applied.
