### PR TITLE
Added support for restart options.

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -146,18 +146,24 @@ Container.prototype.stop = function(opts, callback) {
   });
 };
 
-Container.prototype.restart = function(callback) {
-  var opts = {
+Container.prototype.restart = function(opts, callback) {
+  if (!callback && typeof(opts) === 'function') {
+    callback = opts;
+    opts = null;
+  }
+
+  var optsf = {
     path: '/containers/' + this.id + '/restart',
     method: 'POST',
     statusCodes: {
       204: true,
       404: "no such container",
       500: "server error"
-    }
+    },
+    options: opts
   };
 
-  this.modem.dial(opts, function(err, data) {
+  this.modem.dial(optsf, function(err, data) {
     callback(err, data);
   });
 };

--- a/test/container.js
+++ b/test/container.js
@@ -259,3 +259,53 @@ describe("#container", function() {
     });
   });
 });
+
+describe("#non-responsive container", function() {
+
+  var testContainer;
+  before(function(done){
+    docker.createContainer({
+      Image: 'ubuntu',
+      AttachStdin: false,
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: true,
+      Cmd: ['/bin/sh', '-c', "trap 'echo no' TERM; while true; do sleep 1; done"],
+      OpenStdin: false,
+      StdinOnce: false
+    }, function(err, container) {
+      if (err) done(err);
+      testContainer = container.id;
+      done();
+    });
+  });
+
+  describe("#stop", function() {
+    it("forced after timeout", function(done) {
+      this.timeout(30000);
+      var container = docker.getContainer(testContainer);
+
+      function handler(err, data) {
+        expect(err).to.be.null;
+        done();
+      }
+
+      container.stop({t: 1000}, handler);
+    });
+  });
+
+  describe("#restart", function() {
+    it("forced after timeout", function(done) {
+      this.timeout(30000);
+      var container = docker.getContainer(testContainer);
+
+      function handler(err, data) {
+        expect(err).to.be.null;
+        done();
+      }
+
+      container.restart({t: 1000}, handler);
+    });
+  });
+
+});


### PR DESCRIPTION
The restart function was missing the ability to pass options. Docker supports passing a timeout value used for stopping a container during restart.  This change allows that option to be passed.
