### PR TITLE
New is optional

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -4,6 +4,7 @@ var Modem = require('docker-modem'),
   util = require('./util');
 
 var Docker = function(opts) {
+  if (!(this instanceof Docker)) return new Docker(opts);
   this.modem = new Modem(opts);
 };
 


### PR DESCRIPTION
Great module!

This PR makes the `new` keyword optional when instantiating dockerode which makes it a little harder to mess things up.

``` js
var dockerode = require('dockerode');
var docker = dockerode();
```
