### PR TITLE
bug fix - removed isStream option from image tag

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -79,7 +79,6 @@ Image.prototype.tag = function(opts, callback) {
     path: '/images/' + this.name + '/tag?',
     method: 'POST',
     options: opts,
-    isStream: true,
     statusCodes: {
       201: true,
       400: "bad parameter",


### PR DESCRIPTION
I used the GitHub in browser editor which removed the CRLF.
