### PR TITLE
docker.run: optionally demux stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,19 @@ docker.createImage({fromImage: 'ubuntu'}, function(err, stream) {
 
 * `image` - container image
 * `cmd` - command to be executed
-* `stream` - stream which will be used for execution output.
+* `stream` - stream(s) which will be used for execution output.
 * `callback` - callback called when execution ends.
 
 ``` js
 docker.run('ubuntu', ['bash', '-c', 'uname -a'], process.stdout, function(err, data, container) {
+  console.log(data.StatusCode);
+});
+```
+
+or, if you want to split stdout and stderr (you must to pass `Tty:false` as an option for this to work)
+
+``` js
+docker.run('ubuntu', ['bash', '-c', 'uname -a'], [process.stdout, process.stderr], {Tty:false}, function(err, data, container) {
   console.log(data.StatusCode);
 });
 ```

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -253,9 +253,13 @@ Docker.prototype.run = function(image, cmd, streamo, options, callback) {
     container.attach({stream: true, stdout: true, stderr: true}, function handler(err, stream) {
       if(err) return callback(err, data);
 
-      if(streamo) {
-        stream.setEncoding('utf8');
-        stream.pipe(streamo, {end: true});
+      if (streamo) {
+        if (streamo instanceof Array) {
+          container.modem.demuxStream(stream, streamo[0], streamo[1]);
+        } else {
+          stream.setEncoding('utf8');
+          stream.pipe(streamo, {end: true});
+        }
       }
 
       container.start(function(err, data) {


### PR DESCRIPTION
In order to be able to easily retrieve demuxed std{out,err},
one can now pass an array of two streams as the stream input.
