### PR TITLE
docker.run: emit immediate results

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -1,4 +1,5 @@
-var Modem = require('docker-modem'),
+var EventEmitter = require('events').EventEmitter,
+  Modem = require('docker-modem'),
   Container = require('./container'),
   Image = require('./image'),
   util = require('./util'),
@@ -246,12 +247,18 @@ Docker.prototype.run = function(image, cmd, streamo, options, callback) {
     callback = options;
     options = {};
   }
+  
+  var hub = new EventEmitter();
 
   function handler(err, container) {
     if (err) return callback(err, container);
+    
+    hub.emit('container', container);
 
     container.attach({stream: true, stdout: true, stderr: true}, function handler(err, stream) {
       if(err) return callback(err, data);
+
+      hub.emit('stream', stream);
 
       if(streamo) {
         stream.setEncoding('utf8');
@@ -262,7 +269,10 @@ Docker.prototype.run = function(image, cmd, streamo, options, callback) {
         if(err) return callback(err, data);
 
         container.wait(function(err, data) {
+
+          hub.emit('data', data);
           callback(err, data, container);
+  
         });
       });
     });
@@ -287,6 +297,8 @@ Docker.prototype.run = function(image, cmd, streamo, options, callback) {
   _.extend(optsc, options);
 
   this.createContainer(optsc, handler);
+  
+  return hub;
 };
 
 module.exports = Docker;


### PR DESCRIPTION
In order to have a better way hooking into the immediate steps of docker.run,
emit the resulting container, stream and data via an event emitter that is
returned from the function.

If you don't like this, feel free to reject this, but I found it tremendously useful ;)
