### PR TITLE
container: introduce per-instance default options

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -1,6 +1,21 @@
+var _ = require('underscore');
+
 var Container = function(modem, id) {
   this.modem = modem;
   this.id = id;
+  
+  this.defaultOptions = {
+    top:     {},
+    start:   {},
+    commit:  {},
+    stop:    {},
+    restart: {},
+    resize:  {},
+    attach:  {},
+    remove:  {},
+    copy:    {}
+  };
+  
 };
 
 Container.prototype.inspect = function(callback) {
@@ -37,7 +52,7 @@ Container.prototype.top = function(opts, callback) {
       404: "no such container",
       500: "server error"
     },
-    options: opts
+    options: _.extend({}, this.defaultOptions.top, opts)
   };
 
   this.modem.dial(optsf, function(err, data) {
@@ -92,7 +107,7 @@ Container.prototype.start = function(opts, callback) {
       404: "no such container",
       500: "server error"
     },
-    options: opts
+    options: _.extend({}, this.defaultOptions.start, opts)
   };
 
   this.modem.dial(optsf, function(err, data) {
@@ -116,7 +131,7 @@ Container.prototype.commit = function(opts, callback) {
       404: "no such container",
       500: "server error"
     },
-    options: opts
+    options: _.extend({}, this.defaultOptions.commit, opts)
   };
 
   this.modem.dial(optsf, function(err, data) {
@@ -138,7 +153,7 @@ Container.prototype.stop = function(opts, callback) {
       404: "no such container",
       500: "server error"
     },
-    options: opts
+    options: _.extend({}, this.defaultOptions.stop, opts)
   };
 
   this.modem.dial(optsf, function(err, data) {
@@ -160,7 +175,7 @@ Container.prototype.restart = function(opts, callback) {
       404: "no such container",
       500: "server error"
     },
-    options: opts
+    options: _.extend({}, this.defaultOptions.restart, opts)
   };
 
   this.modem.dial(optsf, function(err, data) {
@@ -188,7 +203,7 @@ Container.prototype.resize = function(opts, callback) {
   var optsf = {
     path: '/containers/' + this.id + '/resize?',
     method: 'POST',
-    options: opts,
+    options: _.extend({}, this.defaultOptions.resize, opts),
     statusCodes: {
       200: true,
       400: 'bad parameter',
@@ -206,7 +221,7 @@ Container.prototype.attach = function(opts, callback) {
   var optsf = {
     path: '/containers/' + this.id + '/attach?',
     method: 'POST',
-    options: opts,
+    options: _.extend({}, this.defaultOptions.attach, opts),
     isStream: true,
     openStdin: opts.stdin,
     statusCodes: {
@@ -253,7 +268,7 @@ Container.prototype.remove = function(opts, callback) {
       404: "no such container",
       500: "server error"
     },
-    options: opts
+    options: _.extend({}, this.defaultOptions.remove, opts)
   };
 
   this.modem.dial(optsf, function(err, data) {
@@ -271,7 +286,7 @@ Container.prototype.copy = function(opts, callback) {
       404: "no such container",
       500: "server error"
     },
-    options: opts
+    options: _.extend({}, this.defaultOptions.copy, opts)
   };
 
   this.modem.dial(optsf, function(err, data) {


### PR DESCRIPTION
In order to be able to set default options for common operations on a container,
introduce a default options object per operation that can be overwritten from the outside.

Together with #60 this resolves #57, because you can now do:

```
docker.run(..., function (...) {
  ...
}).on('container', function (container) {
  container.defaultOptions.start.Binds = ["/tmp:/tmp:rw"];
});
```
