### PR TITLE
Move "Tty" parameter from container.attach() to docker.createContainer()...

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,29 @@ docker.createContainer({Image: 'ubuntu', Cmd: ['/bin/bash']}, function (err, con
 
 ``` js
 //tty:true
-container.attach({stream: true, stdout: true, stderr: true, tty: true}, function (err, stream) {
-  stream.pipe(process.stdout);
-});
+docker.createContainer({ /*...*/ Tty: true /*...*/ }, function(err, container) {
+
+  /* ... */
+
+  container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {
+    stream.pipe(process.stdout);
+  });
+
+  /* ... */
+}
 
 //tty:false
-container.attach({stream: true, stdout: true, stderr: true, tty: false}, function (err, stream) {
-  //dockerode may demultiplex attach streams for you :)
-  container.modem.demuxStream(stream, process.stdout, process.stderr);
-});
+docker.createContainer({ /*...*/ Tty: false /*...*/ }, function(err, container) {
+
+  /* ... */
+
+  container.attach({stream: true, stdout: true, stderr: true}, function (err, stream) {
+    //dockerode may demultiplex attach streams for you :)
+    container.modem.demuxStream(stream, process.stdout, process.stderr);
+  });
+
+  /* ... */
+}
 
 docker.createImage({fromImage: 'ubuntu'}, function (err, stream) {
   stream.pipe(process.stdout);


### PR DESCRIPTION
... in streams documentation section

There is no container.attach() parameter called "tty", this parameter should be defined when creating container.

closes #64
