### PR TITLE
run: properly end demuxed output streams

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -262,6 +262,10 @@ Docker.prototype.run = function(image, cmd, streamo, options, callback) {
 
       if (streamo) {
         if (streamo instanceof Array) {
+          stream.on('end', function () {
+            try { streamo[0].end(); } catch (e) {}
+            try { streamo[1].end(); } catch (e) {}
+          });
           container.modem.demuxStream(stream, streamo[0], streamo[1]);
         } else {
           stream.setEncoding('utf8');


### PR DESCRIPTION
With the current changes regarding apocas/docker-modem#20, there needs to be another way to end the streams passed into `docker.run`.

Since `docker.run` also passes the `end` option to the standard pipe command, this should be coherent behavior.
