### PR TITLE
Set logs to always stream

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -298,7 +298,7 @@ Container.prototype.logs = function(opts, callback) {
   var optsf = {
     path: '/containers/' + this.id + '/logs?',
     method: 'GET',
-    isStream: opts.follow || false,
+    isStream: true,
     statusCodes: {
       200: true,
       404: "no such container",


### PR DESCRIPTION
The Docker remote API always returns a stream. If follow is not specified, you won't be able to demux the stream using the client and then have to do it manually.
