### PR TITLE
changed run_stdin example to also work with detaching command

### DIFF
--- a/examples/run_stdin.js
+++ b/examples/run_stdin.js
@@ -26,7 +26,7 @@ var optsc = {
   'VolumesFrom': ''
 };
 
-var previouKey,
+var previousKey,
     CTRL_P = '\u0010',
     CTRL_Q = '\u0011';
 
@@ -46,8 +46,8 @@ function handler(err, container) {
 
     process.stdin.on('data', function(key) {
       // Detects it is detaching a running container
-      if (previouKey === CTRL_P && key === CTRL_Q) exit(stream, isRaw);
-      previouKey = key;
+      if (previousKey === CTRL_P && key === CTRL_Q) exit(stream, isRaw);
+      previousKey = key;
     });
 
     container.start(function(err, data) {


### PR DESCRIPTION
I have found a way to solve my problem described in this issue #73.

To share with someone else who needs to do the same I have changed `run_stdin.js` example to also work with detaching command.

That allows detach a container without stop it.
