### PR TITLE
Fix for missing socket

### DIFF
--- a/test/spec_helper.js
+++ b/test/spec_helper.js
@@ -6,11 +6,11 @@ var fs     = require('fs');
 // DOCKER_SOCKET=/tmp/docker.sock npm test
 
 
-var socket = process.env.DOCKER_SOCKET || '/var/run/docker.sock';
-var stats  = fs.statSync(socket);
+var socket   = process.env.DOCKER_SOCKET || '/var/run/docker.sock';
+var isSocket = fs.existsSync(socket) ? fs.statSync(socket).isSocket() : false;
 var docker;
 
-if (!stats.isSocket()) {
+if (!isSocket) {
   console.log('Trying TCP connection...');
   docker = new Docker({host: process.env.DOCKER_HOST || 'http://127.0.0.1', port: process.env.DOCKER_PORT || 3000});
   dockert = new Docker({host: process.env.DOCKER_HOST || 'http://127.0.0.1', port: process.env.DOCKER_PORT || 3000, timeout: 1});


### PR DESCRIPTION
```
$ mocha

fs.js:695
  return binding.stat(pathModule._makeLong(path));
                 ^
Error: ENOENT, no such file or directory '/var/run/docker.sock'
    at Object.fs.statSync (fs.js:695:18)
    at Object.<anonymous> (/Users/jacob/Sites/dockerode/test/spec_helper.js:10:17)
```
