### PR TITLE
Doc tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ var docker4 = new Docker({host: '127.0.0.1', port: 3000}); //defaults to http
 ### Manipulating a container:
 
 ``` js
+// create a container entity. does not query API
 var container = docker.getContainer('71501a8ab0f8');
+
+// query API for container info
+container.inspect(function (err, data) {
+  console.log(data);
+});
 
 container.start(function (err, data) {
   console.log(data);


### PR DESCRIPTION
Clarify in README that docker.getContainer only creates an entity whereas container.inspect gets the container's info from the Docker API. 
