### PR TITLE
Expose Container constructor

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -486,4 +486,6 @@ Container.prototype.logs = function(opts, callback) {
   });
 };
 
+Container.Exec = Exec;
+
 module.exports = Container;

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -439,6 +439,7 @@ Docker.prototype.run = function(image, cmd, streamo, createOptions, startOptions
   return hub;
 };
 
+Docker.Image = Image;
 Docker.Container = Container;
 
 module.exports = Docker;


### PR DESCRIPTION
So we can use bluebird's `Promise.promisifyAll`[1*] method like so:

``` javascript
var Promise = require('bluebird')
Promise.promisifyAll(Docker.Container.prototype)

// later on
Docker.createContainer(function(container) {
    container.startAsync().then(function () { ... }); // startAsync is one of the promisified methods
})
```

[1 - https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyallobject-target--object-options---object](https://github.com/petkaantonov/bluebird/blob/master/API.md#promisepromisifyallobject-target--object-options---object)
