### PR TITLE
Allow specifying stdin option for Exec.start method to fully support TTY...

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -26,6 +26,7 @@ Exec.prototype.start = function(opts, callback) {
     path: '/exec/' + this.id + '/start',
     method: 'POST',
     isStream: true,
+    openStdin: opts.stdin,
     statusCodes: {
       200: true,
       404: "no such exec",


### PR DESCRIPTION
...-like interaction from Dockerode

This is needed to properly implement running of interactive commands using the Exec functionality.

Otherwise the dial method returns a one-way stream.
