### PR TITLE
handle 404 in container.unpause

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -190,6 +190,7 @@ Container.prototype.unpause = function(opts, callback) {
     method: 'POST',
     statusCodes: {
       204: true,
+      404: "no such container",
       500: "server error"
     },
     options: opts


### PR DESCRIPTION
I was checking if unpause had been added and noticed the 404 was missing.
