### PR TITLE
Specifies timeout is in milliseconds

### DIFF
--- a/examples/timeout.js
+++ b/examples/timeout.js
@@ -8,8 +8,8 @@ if (!stats.isSocket()) {
   throw new Error("Are you sure the docker is running?");
 }
 
-//you may specify a timeout for all operations, allowing to make sure you don't fall into limbo if something happens in docker
-var docker = new Docker({host: 'http://127.0.0.1', port: 2375, timeout: 1});
+// you may specify a timeout (in ms) for all operations, allowing to make sure you don't fall into limbo if something happens in docker
+var docker = new Docker({host: 'http://127.0.0.1', port: 2375, timeout: 100});
 
 docker.createContainer({Image: 'ubuntu', Cmd: ['/bin/bash']}, function (err, container) {
   container.start(function (err, data) {


### PR DESCRIPTION
After seeing the example use a timeout of just 1, I assumed it was in seconds (like unix `timeout`) and didn't learn otherwise until reading the source of docker-modem. Of course, everything in node is in milliseconds, but it's always best to specify.