### PR TITLE
Add method to get exec instance

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter,
   Modem = require('docker-modem'),
   Container = require('./container'),
   Image = require('./image'),
+  Exec = require('./exec'),
   util = require('./util'),
   extend = util.extend;
 
@@ -162,6 +163,14 @@ Docker.prototype.getContainer = function(id) {
  */
 Docker.prototype.getImage = function(name) {
   return new Image(this.modem, name);
+};
+
+/**
+ * Fetches an Exec instance by ID
+ * @param {String} id Exec instance's ID
+ */
+Docker.prototype.getExec = function(id) {
+  return new Exec(this.modem, id);
 };
 
 /**


### PR DESCRIPTION
Hi, I noticed that there is a way to get a container and an image without querying the Docker API, but for an exec instance this is missing.

I just added it to be able to do:

`var execId = docker.getExec('71501a8ab0f8');`