### PR TITLE
Allow 204 as return code for /exec/:id/start

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -27,6 +27,7 @@ Exec.prototype.start = function(opts, callback) {
     openStdin: opts.stdin,
     statusCodes: {
       200: true,
+      204: true,
       404: "no such exec",
       500: "container not running"
     },


### PR DESCRIPTION
If used with the 'Detach: true' options, the /exec/:id/start endpoint returns 204 (No Content) rather than 200. Dockerode should treat this as a success rather an unhandled error.