### PR TITLE
Fix VolumesFrom crash in Docker 1.7

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -430,7 +430,7 @@ Docker.prototype.run = function(image, cmd, streamo, createOptions, startOptions
     'Cmd': cmd,
     'Image': image,
     'Volumes': {},
-    'VolumesFrom': ''
+    'VolumesFrom': []
   };
 
   extend(optsc, createOptions);


### PR DESCRIPTION
In the latest Docker, they've started to actually enforce the `VolumesFrom` parameter to be an array. It's always been an array, its just that the daemon has been loose about it until now.

I recommend cutting this as a new release ASAP as all use of `docker.run` is broken on Docker 1.7 using `dockerode` until this is fixed.