### PR TITLE
add support for optional `opts` argument to `container.stats()`

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -15,6 +15,8 @@ var Container = function(modem, id) {
     start: {},
     commit: {},
     stop: {},
+    pause: {},
+    unpause: {},
     restart: {},
     resize: {},
     attach: {},
@@ -22,9 +24,23 @@ var Container = function(modem, id) {
     copy: {},
     kill: {},
     exec: {},
-    rename: {}
+    rename: {},
+    log: {},
+    stats: {}
   };
 };
+
+var processArgs = function(opts, callback, defaultOpts) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = null;
+  }
+
+  return {
+    callback: callback,
+    opts: extend({}, defaultOpts, opts)
+  }
+}
 
 /**
  * Inspect
@@ -33,7 +49,7 @@ var Container = function(modem, id) {
  */
 Container.prototype.inspect = function(callback) {
   if (typeof callback === 'function') {
-    var opts = {
+    var optsf = {
       path: '/containers/' + this.id + '/json',
       method: 'GET',
       statusCodes: {
@@ -43,7 +59,7 @@ Container.prototype.inspect = function(callback) {
       }
     };
 
-    this.modem.dial(opts, function(err, data) {
+    this.modem.dial(optsf, function(err, data) {
       callback(err, data);
     });
   } else {
@@ -59,10 +75,7 @@ Container.prototype.inspect = function(callback) {
 * @param  {Function} callback Callback
 */
 Container.prototype.rename = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.rename);
 
   var optsf = {
     path: '/containers/' + this.id + '/rename?',
@@ -72,11 +85,11 @@ Container.prototype.rename = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.rename, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -86,10 +99,7 @@ Container.prototype.rename = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.top = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.top);
 
   var optsf = {
     path: '/containers/' + this.id + '/top?',
@@ -99,11 +109,11 @@ Container.prototype.top = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.top, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -112,7 +122,7 @@ Container.prototype.top = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.changes = function(callback) {
-  var opts = {
+  var optsf = {
     path: '/containers/' + this.id + '/changes',
     method: 'GET',
     statusCodes: {
@@ -122,7 +132,7 @@ Container.prototype.changes = function(callback) {
     }
   };
 
-  this.modem.dial(opts, function(err, data) {
+  this.modem.dial(optsf, function(err, data) {
     callback(err, data);
   });
 };
@@ -132,7 +142,7 @@ Container.prototype.changes = function(callback) {
  * @param  {Function} callback Callback with the octet-stream.
  */
 Container.prototype.export = function(callback) {
-  var opts = {
+  var optsf = {
     path: '/containers/' + this.id + '/export',
     method: 'GET',
     isStream: true,
@@ -143,7 +153,7 @@ Container.prototype.export = function(callback) {
     }
   };
 
-  this.modem.dial(opts, function(err, data) {
+  this.modem.dial(optsf, function(err, data) {
     callback(err, data);
   });
 };
@@ -154,10 +164,7 @@ Container.prototype.export = function(callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.start = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.start);
 
   var optsf = {
     path: '/containers/' + this.id + '/start',
@@ -168,11 +175,11 @@ Container.prototype.start = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.start, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -182,10 +189,7 @@ Container.prototype.start = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.pause = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.pause);
 
   var optsf = {
     path: '/containers/' + this.id + '/pause',
@@ -194,11 +198,11 @@ Container.prototype.pause = function(opts, callback) {
       204: true,
       500: 'server error'
     },
-    options: opts
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -208,10 +212,7 @@ Container.prototype.pause = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.unpause = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.unpause);
 
   var optsf = {
     path: '/containers/' + this.id + '/unpause',
@@ -221,11 +222,11 @@ Container.prototype.unpause = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: opts
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -236,12 +237,7 @@ Container.prototype.unpause = function(opts, callback) {
  * @param {function} callback
  */
 Container.prototype.exec = function(opts, callback) {
-  var self = this;
-
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.exec);
 
   var optsf = {
     path: '/containers/' + this.id + '/exec',
@@ -251,12 +247,13 @@ Container.prototype.exec = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.exec, opts)
+    options: args.opts
   };
 
+  var self = this;
   this.modem.dial(optsf, function(err, data) {
-    if(err) return callback(err, data);
-    callback(err, new Exec(self.modem, data.Id));
+    if(err) return args.callback(err, data);
+    args.callback(err, new Exec(self.modem, data.Id));
   });
 };
 
@@ -266,10 +263,7 @@ Container.prototype.exec = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.commit = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.commit);
 
   opts.container = this.id;
 
@@ -281,11 +275,11 @@ Container.prototype.commit = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.commit, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -295,10 +289,7 @@ Container.prototype.commit = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.stop = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.stop);
 
   var optsf = {
     path: '/containers/' + this.id + '/stop?',
@@ -309,11 +300,11 @@ Container.prototype.stop = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.stop, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -323,10 +314,7 @@ Container.prototype.stop = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.restart = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.restart);
 
   var optsf = {
     path: '/containers/' + this.id + '/restart',
@@ -336,11 +324,11 @@ Container.prototype.restart = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.restart, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -350,10 +338,7 @@ Container.prototype.restart = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.kill = function(opts, callback) {
-  if (!callback && typeof opts === 'function') {
-    callback = opts;
-    opts = null;
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.kill);
 
   var optsf = {
     path: '/containers/' + this.id + '/kill?',
@@ -363,35 +348,36 @@ Container.prototype.kill = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.kill, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
 /**
  * Container resize
- * Warning: Uses an undocumented Docker endpoint. :)
  * @param  {[type]}   opts     Resize options. (optional)
  * @param  {Function} callback Callback
  */
 Container.prototype.resize = function(opts, callback) {
+  var args = processArgs(opts, callback, this.defaultOptions.resize);
+
   var optsf = {
     path: '/containers/' + this.id + '/resize?',
     method: 'POST',
-    options: extend({}, this.defaultOptions.resize, opts),
     statusCodes: {
       200: true,
       400: 'bad parameter',
       404: 'no such container',
       500: 'server error'
-    }
+    },
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -401,21 +387,23 @@ Container.prototype.resize = function(opts, callback) {
  * @param  {Function} callback Callback with stream.
  */
 Container.prototype.attach = function(opts, callback) {
+  var args = processArgs(opts, callback, this.defaultOptions.attach);
+
   var optsf = {
     path: '/containers/' + this.id + '/attach?',
     method: 'POST',
-    options: extend({}, this.defaultOptions.attach, opts),
     isStream: true,
     openStdin: opts.stdin,
     statusCodes: {
       200: true,
       404: 'no such container',
       500: 'server error'
-    }
+    },
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, stream) {
-    callback(err, stream);
+    args.callback(err, stream);
   });
 };
 
@@ -424,7 +412,7 @@ Container.prototype.attach = function(opts, callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.wait = function(callback) {
-  var opts = {
+  var optsf = {
     path: '/containers/' + this.id + '/wait',
     method: 'POST',
     statusCodes: {
@@ -435,7 +423,7 @@ Container.prototype.wait = function(callback) {
     }
   };
 
-  this.modem.dial(opts, function(err, data) {
+  this.modem.dial(optsf, function(err, data) {
     callback(err, data);
   });
 };
@@ -446,10 +434,7 @@ Container.prototype.wait = function(callback) {
  * @param  {Function} callback Callback
  */
 Container.prototype.remove = function(opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
+  var args = processArgs(opts, callback, this.defaultOptions.remove);
 
   var optsf = {
     path: '/containers/' + this.id + '?',
@@ -460,11 +445,11 @@ Container.prototype.remove = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.remove, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
@@ -474,6 +459,8 @@ Container.prototype.remove = function(opts, callback) {
  * @param  {Function} callback Callback with stream.
  */
 Container.prototype.copy = function(opts, callback) {
+  var args = processArgs(opts, callback, this.defaultOptions.copy);
+
   var optsf = {
     path: '/containers/' + this.id + '/copy',
     method: 'POST',
@@ -483,21 +470,22 @@ Container.prototype.copy = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: extend({}, this.defaultOptions.copy, opts)
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
 /**
  * Container logs
- * Warning: Uses an undocumented Docker endpoint. :)
  * @param  {Object}   opts     Logs options. (optional)
  * @param  {Function} callback Callback with data
  */
 Container.prototype.logs = function(opts, callback) {
+  var args = processArgs(opts, callback, this.defaultOptions.log);
+
   var optsf = {
     path: '/containers/' + this.id + '/logs?',
     method: 'GET',
@@ -507,21 +495,22 @@ Container.prototype.logs = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: opts
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 
 /**
 * Container stats
-* Warning: Uses an undocumented Docker endpoint. :)
 * @param  {Object}   opts     Stats options. (optional)
 * @param  {Function} callback Callback with data
 */
-Container.prototype.stats = function(callback) {
+Container.prototype.stats = function(opts, callback) {
+  var args = processArgs(opts, callback, this.defaultOptions.stats);
+
   var optsf = {
     path: '/containers/' + this.id + '/stats?',
     method: 'GET',
@@ -531,11 +520,11 @@ Container.prototype.stats = function(callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: {}
+    options: args.opts
   };
 
   this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
+    args.callback(err, data);
   });
 };
 


### PR DESCRIPTION
In addition to adding support for the `opts` to `container.stats()`, the repeated task of dealing with optional `opts` and the tailing `callback` arguments has been factored out into its own helper function `processArgs()` in order to remove some redundancy.