### PR TITLE
Fix container commit

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -254,7 +254,7 @@ Container.prototype.exec = function(opts, callback) {
 Container.prototype.commit = function(opts, callback) {
   var args = util.processArgs(opts, callback, this.defaultOptions.commit);
 
-  opts.container = this.id;
+  args.opts.container = this.id;
 
   var optsf = {
     path: '/commit?',

--- a/test/container.js
+++ b/test/container.js
@@ -452,6 +452,21 @@ describe("#container", function() {
     });
   });
 
+  describe("#commit", function() {
+    it("should commit a container", function(done) {
+      this.timeout(30000);
+      var container = docker.getContainer(testContainer);
+
+      function handler(err, stream) {
+        expect(err).to.be.null;
+        expect(stream).to.be.ok;
+        done();
+      }
+
+      container.commit({comment: 'dockerode commit test'}, handler);
+    });
+  });
+
   describe("#stop", function() {
     it("should stop a container", function(done) {
       this.timeout(30000);

--- a/test/spec_helper.js
+++ b/test/spec_helper.js
@@ -3,11 +3,19 @@ http.globalAgent.maxSockets = 1000;
 
 var Docker = require('../lib/docker');
 var fs     = require('fs');
+var url    = require('url');
 
 // For Mac OS X:
 // socat -d -d unix-l:/tmp/docker.sock,fork tcp:<docker-host>:4243
 // DOCKER_SOCKET=/tmp/docker.sock npm test
 
+var dockerURL = {
+  hostname: process.env.DOCKER_HOST || '127.0.0.1',
+  port: process.env.DOCKER_PORT || '5555',
+};
+if (/:\/\//.test(process.env.DOCKER_HOST)) {
+  dockerURL = url.parse(process.env.DOCKER_HOST);
+}
 
 var socket   = process.env.DOCKER_SOCKET || '/var/run/docker.sock';
 var isSocket = fs.existsSync(socket) ? fs.statSync(socket).isSocket() : false;
@@ -15,8 +23,8 @@ var docker;
 
 if (!isSocket) {
   console.log('Trying TCP connection...');
-  docker = new Docker({host: process.env.DOCKER_HOST || 'http://127.0.0.1', port: process.env.DOCKER_PORT || 5555});
-  dockert = new Docker({host: process.env.DOCKER_HOST || 'http://127.0.0.1', port: process.env.DOCKER_PORT || 5555, timeout: 1});
+  docker = new Docker({host: dockerURL.hostname, port: dockerURL.port});
+  dockert = new Docker({host: dockerURL.hostname, port: dockerURL.port, timeout: 1});
 } else {
   docker = new Docker({ socketPath: socket });
   dockert = new Docker({ socketPath: socket, timeout: 1 });


### PR DESCRIPTION
This broke in 2.2.0 due to the cleanup of argument parsing because `/commit` is a bit unusual compare to the other `Container` methods. I did a scan and couldn't find anything else that had the same problem.

I also had to modify the spec helper to allow it to use a proper `DOCKER_HOST` if set.