### PR TITLE
Broaden accepted status codes

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -159,6 +159,7 @@ Container.prototype.start = function(opts, callback) {
     path: '/containers/' + this.id + '/start',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       204: true,
       304: 'container already started',
       404: 'no such container',
@@ -184,6 +185,7 @@ Container.prototype.pause = function(opts, callback) {
     path: '/containers/' + this.id + '/pause',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       204: true,
       500: 'server error'
     },
@@ -207,6 +209,7 @@ Container.prototype.unpause = function(opts, callback) {
     path: '/containers/' + this.id + '/unpause',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       204: true,
       404: 'no such container',
       500: 'server error'
@@ -232,6 +235,7 @@ Container.prototype.exec = function(opts, callback) {
     path: '/containers/' + this.id + '/exec',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       201: true,
       404: 'no such container',
       500: 'server error'
@@ -260,6 +264,7 @@ Container.prototype.commit = function(opts, callback) {
     path: '/commit?',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       201: true,
       404: 'no such container',
       500: 'server error'
@@ -284,6 +289,7 @@ Container.prototype.stop = function(opts, callback) {
     path: '/containers/' + this.id + '/stop?',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       204: true,
       304: 'container already stopped',
       404: 'no such container',
@@ -309,6 +315,7 @@ Container.prototype.restart = function(opts, callback) {
     path: '/containers/' + this.id + '/restart',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       204: true,
       404: 'no such container',
       500: 'server error'
@@ -333,6 +340,7 @@ Container.prototype.kill = function(opts, callback) {
     path: '/containers/' + this.id + '/kill?',
     method: 'POST',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       204: true,
       404: 'no such container',
       500: 'server error'
@@ -429,6 +437,7 @@ Container.prototype.remove = function(opts, callback) {
     path: '/containers/' + this.id + '?',
     method: 'DELETE',
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       204: true,
       400: 'bad parameter',
       404: 'no such container',

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -23,6 +23,7 @@ Docker.prototype.createContainer = function(opts, callback) {
     method: 'POST',
     options: opts,
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       201: true,
       404: 'no such container',
       406: 'impossible to attach',

--- a/lib/image.js
+++ b/lib/image.js
@@ -115,6 +115,7 @@ Image.prototype.tag = function(opts, callback) {
     method: 'POST',
     options: opts,
     statusCodes: {
+      200: true, // unofficial, but proxies may return it
       201: true,
       400: 'bad parameter',
       404: 'no such image',

--- a/test/spec_helper.js
+++ b/test/spec_helper.js
@@ -3,19 +3,10 @@ http.globalAgent.maxSockets = 1000;
 
 var Docker = require('../lib/docker');
 var fs     = require('fs');
-var url    = require('url');
 
 // For Mac OS X:
 // socat -d -d unix-l:/tmp/docker.sock,fork tcp:<docker-host>:4243
 // DOCKER_SOCKET=/tmp/docker.sock npm test
-
-var dockerURL = {
-  hostname: process.env.DOCKER_HOST || '127.0.0.1',
-  port: process.env.DOCKER_PORT || '5555',
-};
-if (/:\/\//.test(process.env.DOCKER_HOST)) {
-  dockerURL = url.parse(process.env.DOCKER_HOST);
-}
 
 var socket   = process.env.DOCKER_SOCKET || '/var/run/docker.sock';
 var isSocket = fs.existsSync(socket) ? fs.statSync(socket).isSocket() : false;
@@ -23,8 +14,8 @@ var docker;
 
 if (!isSocket) {
   console.log('Trying TCP connection...');
-  docker = new Docker({host: dockerURL.hostname, port: dockerURL.port});
-  dockert = new Docker({host: dockerURL.hostname, port: dockerURL.port, timeout: 1});
+  docker = new Docker();
+  dockert = new Docker({timeout: 1});
 } else {
   docker = new Docker({ socketPath: socket });
   dockert = new Docker({ socketPath: socket, timeout: 1 });


### PR DESCRIPTION
These endpoints are not documented to return 200's, but proxies like Docker Swarm don't always preserve the status codes (see docker/swarm#1055).

@apocas thoughts?