### PR TITLE
Fixes resizing in stdin example

### DIFF
--- a/examples/run_stdin.js
+++ b/examples/run_stdin.js
@@ -52,7 +52,9 @@ function handler(err, container) {
 
     container.start(function(err, data) {
       resize(container);
-      process.stdout.on('resize', resize);
+      process.stdout.on('resize', function() {
+        resize(container);
+      });
 
       container.wait(function(err, data) {
         exit(stream, isRaw);


### PR DESCRIPTION
Noticed that the example code didn't work properly for resizing the terminal, so I made a quick fix.