### PR TITLE
allow exec.start return a text response

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -19,10 +19,11 @@ var Exec = function(modem, id) {
 Exec.prototype.start = function(opts, callback) {
   var args = util.processArgs(opts, callback);
 
+  args.opts.isStream =  args.opts.isStream===undefined ? true: args.opts.isStream ;
   var optsf = {
     path: '/exec/' + this.id + '/start',
     method: 'POST',
-    isStream: true,
+    isStream: args.opts.isStream,
     openStdin: args.opts.stdin,
     statusCodes: {
       200: true,


### PR DESCRIPTION
sometimes we just need exec a executable file and get string response, but exec.start always return a stream object