### PR TITLE
docker.run: fix callbacks

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -382,12 +382,12 @@ Docker.prototype.run = function(image, cmd, streamo, createOptions, startOptions
   var hub = new EventEmitter();
 
   function handler(err, container) {
-    if (err) return callback(err, container);
+    if (err) return callback(err, null, container);
 
     hub.emit('container', container);
 
     container.attach({stream: true, stdout: true, stderr: true}, function handler(err, stream) {
-      if (err) return callback(err, data);
+      if (err) return callback(err, null, container);
 
       hub.emit('stream', stream);
 
@@ -405,7 +405,7 @@ Docker.prototype.run = function(image, cmd, streamo, createOptions, startOptions
       }
 
       container.start(startOptions, function(err, data) {
-        if(err) return callback(err, data);
+        if(err) return callback(err, data, container);
 
         container.wait(function(err, data) {
           hub.emit('data', data);


### PR DESCRIPTION
Changes all callback invocations to have a common argument format, and fixes a bug where `data` is undefined when calling the callback after a `container.attach` failure.