### PR TITLE
Correct status code

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -70,7 +70,7 @@ Container.prototype.rename = function(opts, callback) {
     path: '/containers/' + this.id + '/rename?',
     method: 'POST',
     statusCodes: {
-      200: true,
+      204: true,
       404: 'no such container',
       500: 'server error'
     },

--- a/lib/container.js
+++ b/lib/container.js
@@ -70,6 +70,7 @@ Container.prototype.rename = function(opts, callback) {
     path: '/containers/' + this.id + '/rename?',
     method: 'POST',
     statusCodes: {
+      200: true,
       204: true,
       404: 'no such container',
       500: 'server error'


### PR DESCRIPTION
The Docker API returns a 204 when the container is renamed, not a 200, which causes this method to throw an error.