### PR TITLE
fix failing createVolume tests

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -272,10 +272,8 @@ Docker.prototype.createVolume = function(opts, callback) {
     };
 
     this.modem.dial(optsf, function(err, data) {
-      if(err) {
-        return args.callback(err);
-      }
-      args.callback(undefined, self.getVolume(data.Name));
+      if(err) return args.callback(err, data);
+      args.callback(err, self.getVolume(data.Name));
     });
 };
 


### PR DESCRIPTION
The tests are explicitly checking for null, which is what all the other
methods use as a non-Error value.