### PR TITLE
add support for raw TCP socket upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ docker.createImage({fromImage: 'ubuntu'}, function (err, stream) {
 //...
 ```
 
+There is also support for [HTTP connection hijacking](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/#3-2-hijacking),
+which allows for cleaner interactions with commands that work with stdin and stdout separately.
+
+```js
+docker.createContainer({Tty: false, /*... other options */}, function(err, container) {
+  container.exec({Cmd: ['shasum', '-'], AttachStdin: true, AttachStdout: true}, function(err, exec) {
+    exec.start({hijack: true, stdin: true}, function(err, stream) {
+      // shasum can't finish until after its stdin has been closed, telling it that it has
+      // read all the bytes it needs to sum. Without a socket upgrade, there is no way to
+      // close the write-side of the stream without also closing the read-side!
+      fs.createReadStream('node-v5.1.0.tgz', 'binary').pipe(stream);
+
+      // Fortunately, we have a regular TCP socket now, so when the readstream finishes and closes our
+      // stream, it is still open for reading and we will still get our results :-)
+      docker.modem.demuxStream(stream, process.stdout, process.stderr);
+    });
+  });
+});
+```
+
 ### Equivalent of `docker run` in `dockerode`:
 
 * `image` - container image

--- a/lib/container.js
+++ b/lib/container.js
@@ -394,6 +394,7 @@ Container.prototype.attach = function(opts, callback) {
     path: '/containers/' + this.id + '/attach?',
     method: 'POST',
     isStream: true,
+    hijack: args.opts.hijack,
     openStdin: args.opts.stdin,
     statusCodes: {
       200: true,

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -23,6 +23,7 @@ Exec.prototype.start = function(opts, callback) {
     path: '/exec/' + this.id + '/start',
     method: 'POST',
     isStream: true,
+    hijack: args.opts.hijack,
     openStdin: args.opts.stdin,
     statusCodes: {
       200: true,


### PR DESCRIPTION
This is supported by the /exec/(id)/start and /containers/(id)/attach
endpoints, allowing the HTTP request/response to be hijacked and turned
in to a regular TCP socket. This allows for useful features such as
half-closed sockets, which properly represents how a command's stdin
can be closed and it can still write output to stdout.

Requires HTTP->TCP connection 'upgrading' from docker-modem, which is
proposed in apocas/docker-modem#54.