### PR TITLE
filtering by labels example + tests

### DIFF
--- a/examples/listContainers.js
+++ b/examples/listContainers.js
@@ -14,6 +14,12 @@ docker.listContainers({all: true}, function(err, containers) {
   console.log('ALL: ' + containers.length);
 });
 
-docker.listContainers({all: false}, function(err, containers) {
-  console.log('!ALL: ' + containers.length);
+// filter by labels
+var opts = {
+  "limit": 3,
+  "filters": '{"label": ["staging","env=green"]}'
+};
+
+docker.listContainers(opts, function(err, containers) {
+  console.log('Containers labeled staging + env=green : ' + containers.length);
 });

--- a/test/docker.js
+++ b/test/docker.js
@@ -421,7 +421,7 @@ describe("#docker", function() {
 
   describe("#listImages", function() {
     it("should list images", function(done) {
-      this.timeout(5000);
+      this.timeout(10000);
 
       function handler(err, data) {
         expect(err).to.be.null;

--- a/test/docker.js
+++ b/test/docker.js
@@ -507,4 +507,78 @@ describe("#docker", function() {
       docker.info(handler);
     });
   });
+
+  describe("#labelsAndFilters", function() {
+
+    var test_container;
+    var test_container_name = 'dockerode_test_querystring';
+    var labels = {
+      "dockerode-test": "",
+      "dockerode-test-value": "works"
+    };
+
+    // cleanup querystring container after tests
+    after(function(done){
+      if (!test_container) return done();
+      test_container.remove(function(err, data) {
+        return done(err);
+      });
+    });
+
+
+    it("should create a container from a map of labels", function(done){
+      this.timeout(5000);
+
+      function handler(err, container) {
+        expect(err).to.be.null;
+        expect(container).to.be.ok;
+        test_container = container;
+        done();
+      };
+
+      docker.createContainer({
+        "Image": testImage,
+        "Cmd": ['/bin/bash'],
+        "Labels": labels,
+        "name": test_container_name
+      }, handler);
+
+    });
+
+    it("should have the same labels used to create it", function(done){
+      test_container.inspect(function(err, info) {
+        expect(err).to.be.null;
+        expect(info.Name).to.equal('/' + test_container_name);
+        expect(info.Config.Labels).to.deep.equal(labels);
+        done();
+      });
+    });
+
+    it("should appear in listings filtering by a string of labels", function(done){
+      docker.listContainers({
+        "limit": 3,
+        "filters": '{"label": ["dockerode-test", "dockerode-test-value=works"]}'
+      }, function(err, data){
+        expect(data.length).to.equal(1);
+        done();
+      });
+
+    });
+
+    /*
+     * the qs library does not serialize into the format expected by docker
+     *   commenting out until a workaround/util function is introduced
+     *
+    it("should appear in listings filtering a array of labels", function(done){
+      docker.listContainers({
+        "limit": 3,
+        "filters": {"label": ["dockerode-test"]}
+      }, function(err, data){
+        expect(data.length).to.equal(1);
+        done();
+      });
+    });
+    */
+
+  });
 });


### PR DESCRIPTION
in relation to:  https://github.com/apocas/docker-modem/pull/57

unfortunately I was not able to get the `qs` library to serialize the querystring to what the docker api expects. for now I think we need to stick w/ the manual string representation. 

included is an example and unit test to help clarify this for existing users. 