### PR TITLE
Allow an optional opts argument to Container.inspect

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -36,23 +36,26 @@ var Container = function(modem, id) {
 
 /**
  * Inspect
+ * @param  {Options}  opts     Options (optional)
  * @param  {Function} callback Callback, if supplied will query Docker.
  * @return {Object}            ID only and only if callback isn't supplied.
  */
-Container.prototype.inspect = function(callback) {
-  if (typeof callback === 'function') {
-    var optsf = {
-      path: '/containers/' + this.id + '/json',
-      method: 'GET',
-      statusCodes: {
-        200: true,
-        404: 'no such container',
-        500: 'server error'
-      }
-    };
+Container.prototype.inspect = function(opts, callback) {
+  var args = util.processArgs(opts, callback);
+  var optsf = {
+    path: '/containers/' + this.id + '/json?',
+    method: 'GET',
+    options: args.opts,
+    statusCodes: {
+      200: true,
+      404: 'no such container',
+      500: 'server error'
+    }
+  };
 
+  if (typeof args.callback === 'function') {
     this.modem.dial(optsf, function(err, data) {
-      callback(err, data);
+      args.callback(err, data);
     });
   } else {
     return JSON.stringify({

--- a/test/container.js
+++ b/test/container.js
@@ -37,6 +37,18 @@ describe("#container", function() {
 
       container.inspect(handler);
     });
+
+    it("should inspect a container with opts", function(done) {
+      var container = docker.getContainer(testContainer);
+
+      function handler(err, data) {
+        expect(err).to.be.null;
+        expect(data).to.be.ok;
+        done();
+      }
+
+      container.inspect({}, handler);
+    });
   });
 
   describe("#archive", function() {


### PR DESCRIPTION
Newly released Docker 1.9.x and APIs add support for getting container size information as part of the docker [inspect](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/#inspect-a-container) API call.

This pull request adds support calling this API by passing in a `{size: true}` `opts`, which turn into URL query params sent to the API. This change is fully backwards compatible.