### PR TITLE
add test and examples for filtering by map

### DIFF
--- a/examples/listContainers.js
+++ b/examples/listContainers.js
@@ -24,6 +24,14 @@ var opts = {
   "filters": '{"label": ["staging","env=green"]}'
 };
 
+// maps are also supported (** requires docker-modem 0.3+ **)
+opts["filters"] = {
+  "label": [
+    "staging",
+    "env=green"
+  ]
+};
+
 docker.listContainers(opts, function(err, containers) {
   console.log('Containers labeled staging + env=green : ' + containers.length);
 });

--- a/test/docker.js
+++ b/test/docker.js
@@ -573,5 +573,18 @@ describe("#docker", function() {
         done();
       });
     });
+
+    it("should query containers filtering by map of valued labels", function(done){
+      docker.listContainers({
+        "limit": 3,
+        "filters": {
+          "label": ["dockerode-test-label","dockerode-test-value-label=assigned"]
+        }
+      }, function(err, data){
+        expect(data.length).to.equal(1);
+        done();
+      });
+    });
+
   });
 });


### PR DESCRIPTION
requires docker-modem 0.3

@apocas as promised,  tests and example usage for the updated querysting behavior. 

Many thanks for merging my PR and for this module :) It's a ton of fun to play with docker in node. 