### PR TITLE
Adds on 'start' event to docker.run

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -572,6 +572,7 @@ Docker.prototype.run = function(image, cmd, streamo, createOptions, startOptions
 
       container.start(startOptions, function(err, data) {
         if (err) return callback(err, data, container);
+        hub.emit('start', container);
 
         container.wait(function(err, data) {
           hub.emit('data', data);

--- a/test/docker.js
+++ b/test/docker.js
@@ -271,6 +271,12 @@ describe("#docker", function() {
       ee.on('stream', function(stream) {
         expect(stream).to.be.ok;
       });
+      ee.on('start', function(container) {
+        expect(container).to.be.ok;
+        container.inspect(function(err, info) {
+          expect(info.State.Status).to.equal('running')
+        })
+      })
       ee.on('data', function(data) {
         expect(data).to.be.ok;
         done();


### PR DESCRIPTION
This is useful when you need to run commands once the container already is running, not just created.