### PR TITLE
Support building image from multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ docker.listContainers(function (err, containers) {
 docker.buildImage('archive.tar', {t: imageName}, function (err, response){
   //...
 });
+
+docker.buildImage({
+  context: __dirname,
+  src: ['Dockerfile', 'file1', 'file2']
+}, {t: imageName}, function (err, response) {
+  //...
+});
 ```
 
 ### Creating a container:

--- a/examples/build/build_img_files.js
+++ b/examples/build/build_img_files.js
@@ -1,12 +1,12 @@
-var Docker = require('../../lib/docker'),
-  tar = require('tar-fs');
-
+var Docker = require('../../lib/docker');
 var docker = new Docker({
   socketPath: '/var/run/docker.sock'
 });
 
-var tarStream = tar.pack(process.cwd());
-docker.buildImage(tarStream, {
+docker.buildImage({
+  context: __dirname,
+  src: ['Dockerfile', 'run.js']
+}, {
   t: 'imgcwd'
 }, function(error, output) {
   if (error) {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -1,5 +1,10 @@
 var EventEmitter = require('events').EventEmitter,
   Modem = require('docker-modem'),
+  tar = require('tar-fs'),
+  zlib = require('zlib'),
+  fs = require('fs'),
+  concat = require('concat-stream'),
+  path = require('path'),
   Container = require('./container'),
   Image = require('./image'),
   Volume = require('./volume'),
@@ -162,40 +167,56 @@ Docker.prototype.checkAuth = function(opts, callback) {
  * @param {Function} callback Callback
  */
 Docker.prototype.buildImage = function(file, opts, callback) {
+  var pack = tar.pack();
+  var content;
+  var self = this;
+
   if (!callback && typeof opts === 'function') {
     callback = opts;
     opts = null;
   }
 
-  var self = this;
-  var optsf = {
-    path: '/build?',
-    method: 'POST',
-    file: file,
-    options: opts,
-    isStream: true,
-    statusCodes: {
-      200: true,
-      500: 'server error'
-    }
-  };
+  function build(file) {
+    var optsf = {
+      path: '/build?',
+      method: 'POST',
+      file: file,
+      options: opts,
+      isStream: true,
+      statusCodes: {
+        200: true,
+        500: 'server error'
+      }
+    };
 
-  if (opts) {
-    if (opts.registryconfig) {
-      optsf.registryconfig = optsf.options.registryconfig;
-      delete optsf.options.registryconfig;
+    if (opts) {
+      if (opts.registryconfig) {
+        optsf.registryconfig = optsf.options.registryconfig;
+        delete optsf.options.registryconfig;
+      }
+
+      //undocumented?
+      if (opts.authconfig) {
+        optsf.authconfig = optsf.options.authconfig;
+        delete optsf.options.authconfig;
+      }
     }
 
-    //undocumented?
-    if (opts.authconfig) {
-      optsf.authconfig = optsf.options.authconfig;
-      delete optsf.options.authconfig;
-    }
+    self.modem.dial(optsf, function(err, data) {
+      callback(err, data);
+    });
   }
 
-  this.modem.dial(optsf, function(err, data) {
-    callback(err, data);
-  });
+  if (file.context) {
+    file.src.forEach(function(filePath) {
+      content = fs.readFileSync(path.join(file.context, filePath));
+      pack.entry({ name: filePath }, content);
+    });
+    pack.finalize();
+    pack.pipe(zlib.createGzip()).pipe(concat(build));
+  } else {
+    build(file);
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "docker.io"
   ],
   "dependencies": {
-    "docker-modem": "0.3.x"
+    "concat-stream": "~1.5.1",
+    "docker-modem": "0.3.x",
+    "tar-fs": "~1.12.0"
   },
   "devDependencies": {
     "chai": "~1.7.0",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu
+
+RUN echo test
+
+CMD ["bash"]

--- a/test/docker.js
+++ b/test/docker.js
@@ -78,6 +78,28 @@ describe("#docker", function() {
       var data = require('fs').createReadStream('./test/test.tar');
       docker.buildImage(data, handler);
     });
+
+    it("should build image from multiple files", function() {
+      this.timeout(60000);
+
+      function handler(err, stream) {
+        expect(err).to.be.null;
+        expect(stream).to.be.ok;
+
+        stream.pipe(process.stdout, {
+          end: true
+        });
+
+        stream.on('end', function() {
+          done();
+        });
+      }
+
+      docker.buildImage({
+        context: __dirname,
+        src: ['Dockerfile']
+      }, {}, handler);
+    });
   });
 
 


### PR DESCRIPTION
Example:

``` JavaScript
docker.buildImage({
  context: __dirname,
  src: ['Dockerfile', 'file1', 'file2']
}, {t: imageName}, function (err, response) {
  //...
});
```

If this PR is accepted, I will send another PR to support `src` as directories

Inspired by https://github.com/JoTrdl/grunt-dock
