### PR TITLE
fix container stats to work with stream option true or false

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -625,11 +625,14 @@ Container.prototype.logs = function(opts, callback) {
  */
 Container.prototype.stats = function(opts, callback) {
   var args = util.processArgs(opts, callback, this.defaultOptions.stats);
-
+  var isStream = true;
+  if(args.opts.stream == false){
+    isStream = false;
+  }
   var optsf = {
     path: '/containers/' + this.id + '/stats?',
     method: 'GET',
-    isStream: true,
+    isStream: isStream,
     statusCodes: {
       200: true,
       404: 'no such container',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dockerode",
   "description": "Docker Remote API module.",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "author": "Pedro Dias <petermdias@gmail.com>",
   "maintainers": [
     "apocas <petermdias@gmail.com>"


### PR DESCRIPTION
isStream is hardcoded to true, so there is no way to get stats without streaming.
This small change resolves that while still allowing the default streaming functionality
Issue #255 