### PR TITLE
Tasks.inspect calls the 'tasks' path.

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -17,10 +17,8 @@ var Task = function(modem, id) {
  * @param {function} callback
  */
 Task.prototype.inspect = function(callback) {
-  var args = util.processArgs(opts, callback);
-
   var optsf = {
-    path: '/nodes/' + this.id,
+    path: '/tasks/' + this.id,
     method: 'GET',
     statusCodes: {
       200: true,
@@ -30,7 +28,7 @@ Task.prototype.inspect = function(callback) {
   };
 
   this.modem.dial(optsf, function(err, data) {
-    args.callback(err, data);
+    callback(err, data);
   });
 };
 


### PR DESCRIPTION
The old references to 'nodes' are replaced by 'tasks'.
'opts' is not part of the tasks.inspect API.