### PR TITLE
Pass auth header on service creation and update

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -408,14 +408,18 @@ Docker.prototype.createVolume = function(opts, callback) {
  * @param {Object}   opts     Create options
  * @param {Function} callback Callback
  */
-Docker.prototype.createService = function(opts, callback) {
-  var args = util.processArgs(opts, callback);
-
+Docker.prototype.createService = function(auth, opts, callback) {
+  if (!callback && typeof opts === 'function') {
+    callback = opts;
+    opts = auth;
+    auth = opts.authconfig || undefined;
+  }
   var self = this;
   var optsf = {
     path: '/services/create',
     method: 'POST',
-    options: args.opts,
+    options: opts,
+    authconfig: auth,
     statusCodes: {
       200: true,
       201: true,
@@ -424,9 +428,9 @@ Docker.prototype.createService = function(opts, callback) {
   };
 
   this.modem.dial(optsf, function(err, data) {
-    if (err) return args.callback(err, data);
+    if (err) return callback(err, data);
 
-    args.callback(err, self.getService(data.ID || data.Id));
+    callback(err, self.getService(data.ID || data.Id));
   });
 };
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -60,9 +60,12 @@ Service.prototype.remove = function(callback) {
  * @param {object} options
  * @param {function} callback
  */
-Service.prototype.update = function(opts, callback) {
-  var args = util.processArgs(opts, callback);
-
+Service.prototype.update = function(auth, opts, callback) {
+  if (!callback && typeof opts === 'function') {
+    callback = opts;
+    opts = auth;
+    auth = opts.authconfig || undefined;
+  }
   var optsf = {
     path: '/services/' + this.id + '/update?',
     method: 'POST',
@@ -71,11 +74,11 @@ Service.prototype.update = function(opts, callback) {
       404: 'no such service',
       500: 'server error'
     },
-    options: args.opts
+    authconfig: auth,
+    options: opts
   };
-
   this.modem.dial(optsf, function(err, data) {
-    args.callback(err, data);
+    callback(err, data);
   });
 };
 


### PR DESCRIPTION
When using Dockerode, I wanted to create and update services using images from a private registry. To do so, you need to pass an authconfig to docker-modem, which will generate an X-Registry-Auth token when talking with the API.

This merge request enables us to add authconfig as a first parameter to `docker.CreateService` and `service.UpdateService`