### PR TITLE
add Node.remove hidden API

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -39,4 +39,34 @@ Node.prototype.inspect = function(callback) {
 };
 
 
+/**
+ * Remove a Node.
+ * Warning: This method is not documented in the API.
+ *
+ * @param {object} options
+ * @param {function} callback
+ */
+Node.prototype.remove = function(callback) {
+  if (typeof callback !== 'function') {
+    return JSON.stringify({
+      id: this.id
+    });
+  }
+
+  var optsf = {
+    path: '/nodes/' + this.id,
+    method: 'DELETE',
+    statusCodes: {
+      200: true,
+      404: 'no such node',
+      500: 'server error'
+    }
+  };
+
+  this.modem.dial(optsf, function(err, data) {
+    callback(err, data);
+  });
+};
+
+
 module.exports = Node;

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -222,6 +222,16 @@ describe("#swarm", function() {
         }
         node.inspect(handler);
       });
+
+      it("should remove node", function(done) {
+        function handler(err, data) {
+	  // error is [Error: (HTTP code 500) server error - rpc error: code = 9 desc = node xxxxxxxxxx is a cluster manager and is a member of the raft cluster. It must be demoted to worker before removal ] 
+          expect(err).to.not.be.null;
+          expect(data).to.be.null;
+          done();
+        }
+        node.remove(handler);
+      });
     });
   });
 
@@ -241,5 +251,4 @@ describe("#swarm", function() {
       );
     });
   });
-
 });


### PR DESCRIPTION
Some context:
In the API, `/swarm/leave` doesn't remove the node in the manager. If you loop `swarm/join` and `swarm/leave`, you'll find many node in the '_down_' state.

The method to remove a node in a manager is `DELETE /nodes/<id>`.

