### PR TITLE
add swarmInspect hidden api.

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -821,4 +821,26 @@ Docker.prototype.swarmUpdate = function(opts, callback) {
 };
 
 
+/**
+ * Inspect a Swarm.
+ * Warning: This method is not documented in the API
+ *
+ * @param  {Function} callback Callback
+ */
+Docker.prototype.swarmInspect = function(callback) {
+  var optsf = {
+    path: '/swarm',
+    method: 'GET',
+    statusCodes: {
+      200: true,
+      406: 'This node is not a swarm manager',
+      500: 'server error'
+    }
+  };
+
+  this.modem.dial(optsf, function(err, data) {
+    callback(err, data);
+  });
+};
+
 module.exports = Docker;

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -34,6 +34,16 @@ describe("#swarm", function() {
 
       docker.swarmInit(opts, handler);
     });
+
+    it("should inspect swarm", function(done) {
+      function handler(err, data) {
+        expect(err).to.be.null;
+        expect(data).to.be.a('object');
+        done();
+      }
+      
+      docker.swarmInspect(handler);
+    });
   });
 
   describe("#Services", function() {


### PR DESCRIPTION
Some context:
To join a swarm, you need a _joinToken_. You find the joinToken with `GET /swarm`.