### PR TITLE
[Bug] Cannot get a network by Id

### DIFF
--- a/test/networks.js
+++ b/test/networks.js
@@ -96,6 +96,17 @@ describe("#networks", function() {
       network.inspect(handler);
     });
   });
+  describe("#get", function() {
+    it("should get a network by ID", function(done) {
+      function handler(err, data) {
+        expect(err).to.be.null;
+        expect(data).to.be.ok;
+        expect(data.Id).to.not.be.null;
+        done();
+      }
+      docker.getNetwork(testNetwork.Id, handler);
+    });
+  });
 
   describe("#disconnect", function() {
     it("should disconnect a container to a network", function(done) {


### PR DESCRIPTION
I cannot get a network by ID, as the the callback of `getNetwork` is never called.
Tested on master branch of dockerode. Tested on docker version version:
```
$ docker -v
Docker version 1.12.2, build bb80604
```