### PR TITLE
Promise needs to be returned

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -302,7 +302,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
     pack.finalize();
     pack.pipe(zlib.createGzip()).pipe(concat(build));
   } else {
-    build(file);
+    return build(file);
   }
 };
 


### PR DESCRIPTION
`buildImage()` currently returns undefined when called without a callback, needs to return the result of `build()` instead, so we get a Promise