### PR TITLE
should use self instead of this

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -70,7 +70,7 @@ Network.prototype.remove = function(opts, callback) {
 
   if(args.callback === undefined) {
     return new this.modem.Promise(function(resolve, reject) {
-      this.modem.dial(optsf, function(err, data) {
+      self.modem.dial(optsf, function(err, data) {
         if (err) {
           return reject(err);
         }


### PR DESCRIPTION
when acting upon promises, a network refuses to be removed and gives `Cannot read property 'dial' of undefined` error