### PR TITLE
On createImage, adding use of 'authconfig'.

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -86,6 +86,7 @@ Docker.prototype.createImage = function(auth, opts, callback) {
     auth = opts.authconfig || undefined;
   } else if (!callback && !opts) {
     opts = auth;
+    auth = opts.authconfig;
   }
 
   var optsf = {


### PR DESCRIPTION
On case of using the function createImage with options object and no callback, the user will be able to give the credential via the `authconfig` option