### PR TITLE
Support authconfig in createContainer

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -46,6 +46,7 @@ Docker.prototype.createContainer = function(opts, callback) {
     path: '/containers/create?',
     method: 'POST',
     options: opts,
+    authconfig: opts.authconfig,
     statusCodes: {
       200: true, // unofficial, but proxies may return it
       201: true,
@@ -54,6 +55,8 @@ Docker.prototype.createContainer = function(opts, callback) {
       500: 'server error'
     }
   };
+
+  delete opts.authconfig;
 
   if (callback === undefined) {
     return new this.modem.Promise(function(resolve, reject) {


### PR DESCRIPTION
When createContainer points to Docker Swarm Manager, it can pull missing image, but it needs `authconfig`.
