### PR TITLE
Offer a more intuitive way to name new containers

### DIFF
--- a/examples/run.js
+++ b/examples/run.js
@@ -26,7 +26,7 @@ docker.run('ubuntu', [], process.stdout, {
 
 //run and give a container a name and a label
 docker.run('redis', [], undefined, {
-  "Name": 'MyNamedContainer',
+  "name": 'MyNamedContainer',
   "Labels": {
     "environment": "blueWhale"
   },

--- a/examples/run.js
+++ b/examples/run.js
@@ -25,8 +25,8 @@ docker.run('ubuntu', [], process.stdout, {
 
 
 //run and give a container a name and a label
-docker.run('redis', [], process.stdout, {
-  "Name": 'MyNamedContainer',
+docker.run('redis', [], undefined, {
+  "name": 'MyNamedContainer',
   "Labels": {
     "environment": "blueWhale"
   },

--- a/examples/run.js
+++ b/examples/run.js
@@ -16,5 +16,32 @@ docker.run('ubuntu', [], process.stdout, {
     'Binds': ['/home/vagrant:/stuff'],
   }
 }, function(err, data, container) {
+  if (err){
+    return console.error(err);
+  }
+  console.log(data.StatusCode);
+});
+
+
+
+//run and give a container a name and a label
+docker.run('redis', [], process.stdout, {
+  "Name": 'MyNamedContainer',
+  "Labels": {
+    "environment": "blueWhale"
+  },
+  "HostConfig": {
+    "PortBindings": {
+      "6379/tcp": [
+        {
+          "HostPort": "0"   //Map container to a random unused port.
+        }
+      ]
+    }
+  }
+}, function(err, data, container) {
+  if (err){
+    return console.error(err);
+  }
   console.log(data.StatusCode);
 });

--- a/examples/run.js
+++ b/examples/run.js
@@ -26,7 +26,7 @@ docker.run('ubuntu', [], process.stdout, {
 
 //run and give a container a name and a label
 docker.run('redis', [], undefined, {
-  "name": 'MyNamedContainer',
+  "Name": 'MyNamedContainer',
   "Labels": {
     "environment": "blueWhale"
   },

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -42,6 +42,13 @@ var Docker = function(opts) {
  */
 Docker.prototype.createContainer = function(opts, callback) {
   var self = this;
+
+  //If they specified a container name and they aren't using _query map it for the query string parameter lowercase.
+  if (typeof opts.Name === 'string' && typeof opts._query === 'undefined'){
+    opts._query = { name: opts.Name };
+    delete opts.Name;
+  }
+
   var optsf = {
     path: '/containers/create?',
     method: 'POST',

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -42,13 +42,6 @@ var Docker = function(opts) {
  */
 Docker.prototype.createContainer = function(opts, callback) {
   var self = this;
-
-  //If they specified a container name and they aren't using _query map it for the query string parameter lowercase.
-  if (typeof opts.Name === 'string' && typeof opts._query === 'undefined'){
-    opts._query = { name: opts.Name };
-    delete opts.Name;
-  }
-
   var optsf = {
     path: '/containers/create?',
     method: 'POST',


### PR DESCRIPTION
I spent a while digging down into dockerode and docker-modem trying to find a way to specify a name for Container Create which requires a querystring argument.  

I had a solution with the _query object that worked if I specified 'name' lower case, but it looked quite un-documented and hacky, so I figured I'd add a more intuitive way to specify the name of new containers with a 'Name' property next to all the others.

(https://docs.docker.com/engine/api/v1.29/#operation/ContainerCreate)

