### PR TITLE
Add ability to omit file to allow for remote context

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -296,7 +296,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
     }
   }
 
-  if (file.context) {
+  if (file && file.context) {
     file.src.forEach(function(filePath) {
       content = fs.readFileSync(path.join(file.context, filePath));
       pack.entry({


### PR DESCRIPTION
The current code requires a file to be specified however it is now possible to build an image only using a git URL. With this change, file can be set to `null` to not send any tar archive and instead use the `remote` parameter.

Closes #380 