### PR TITLE
container restart options

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -609,7 +609,7 @@ Container.prototype.restart = function(opts, callback) {
   var args = util.processArgs(opts, callback, this.defaultOptions.restart);
 
   var optsf = {
-    path: '/containers/' + this.id + '/restart',
+    path: '/containers/' + this.id + '/restart?',
     method: 'POST',
     statusCodes: {
       200: true, // unofficial, but proxies may return it


### PR DESCRIPTION
Change needed to make restart timeout parameter work. E.g.
container.restart({t: 0}).then(...)