### PR TITLE
Respect follow option on logs endpoint (default false)

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -989,7 +989,7 @@ Container.prototype.logs = function(opts, callback) {
   var optsf = {
     path: '/containers/' + this.id + '/logs?',
     method: 'GET',
-    isStream: true,
+    isStream: args.opts.follow || false,
     statusCodes: {
       200: true,
       404: 'no such container',

--- a/lib/service.js
+++ b/lib/service.js
@@ -143,7 +143,7 @@ Service.prototype.logs = function(opts, callback) {
   var optsf = {
     path: '/services/' + this.id + '/logs?',
     method: 'GET',
-    isStream: true,
+    isStream: (typeof(args.opts.follow) != 'undefined') ? args.opts.follow : false,
     statusCodes: {
       200: true,
       404: 'no such service',

--- a/lib/service.js
+++ b/lib/service.js
@@ -143,7 +143,7 @@ Service.prototype.logs = function(opts, callback) {
   var optsf = {
     path: '/services/' + this.id + '/logs?',
     method: 'GET',
-    isStream: (typeof(args.opts.follow) != 'undefined') ? args.opts.follow : false,
+    isStream: args.opts.follow || false,
     statusCodes: {
       200: true,
       404: 'no such service',

--- a/lib/task.js
+++ b/lib/task.js
@@ -59,7 +59,7 @@ Task.prototype.logs = function(opts, callback) {
   var optsf = {
     path: '/tasks/' + this.id + '/logs?',
     method: 'GET',
-    isStream: args.opts.follow || false,
+    isStream: (typeof(args.opts.follow) != 'undefined') ? args.opts.follow : false,
     statusCodes: {
       101: true,
       200: true,

--- a/lib/task.js
+++ b/lib/task.js
@@ -59,7 +59,7 @@ Task.prototype.logs = function(opts, callback) {
   var optsf = {
     path: '/tasks/' + this.id + '/logs?',
     method: 'GET',
-    isStream: (typeof(args.opts.follow) != 'undefined') ? args.opts.follow : false,
+    isStream: args.opts.follow || false,
     statusCodes: {
       101: true,
       200: true,


### PR DESCRIPTION
By default the follow option in the container and service endpoint is false. This fix follows this definition and sets the isStream variable accordingly.

Best