### PR TITLE
Pack files only if required when building

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -248,6 +248,7 @@ Docker.prototype.checkAuth = function(opts, callback) {
 Docker.prototype.buildImage = function(file, opts, callback) {
   var self = this;
   var content;
+  var pack;
 
   if (!callback && typeof opts === 'function') {
     callback = opts;
@@ -297,7 +298,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
   }
 
   if (file && file.context) {
-    var pack = tar.pack(file.context, {
+    pack = tar.pack(file.context, {
       entries: file.src
     });
     return build(pack.pipe(zlib.createGzip()));

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -297,14 +297,9 @@ Docker.prototype.buildImage = function(file, opts, callback) {
   }
 
   if (file && file.context) {
-    var pack = tar.pack();
-    file.src.forEach(function(filePath) {
-      content = fs.readFileSync(path.join(file.context, filePath));
-      pack.entry({
-        name: filePath
-      }, content);
+    var pack = tar.pack(file.context, {
+      entries: file.src
     });
-    pack.finalize();
     return build(pack.pipe(zlib.createGzip()));
   } else {
     return build(file);

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -247,7 +247,6 @@ Docker.prototype.checkAuth = function(opts, callback) {
  */
 Docker.prototype.buildImage = function(file, opts, callback) {
   var self = this;
-  var pack = tar.pack();
   var content;
 
   if (!callback && typeof opts === 'function') {
@@ -298,6 +297,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
   }
 
   if (file && file.context) {
+    var pack = tar.pack();
     file.src.forEach(function(filePath) {
       content = fs.readFileSync(path.join(file.context, filePath));
       pack.entry({


### PR DESCRIPTION
`tar.pack()` creates a tarball of all files in the current working directory. This can take a fair amount of IO and time, and cause problems (https://github.com/resin-io/resin-cli/issues/824).

Right now in `buildImage`, Dockerode creates a tarball initially (and therefore reads & compresses every file in the CWD) in all cases, and then only if you've passed the details of some files in your context (rather than passing a tarball directly) does it add more files to the tarball and use it.

This PR changes this so that:
* No tarball is created at all if you've passed one already
* If you do need to build a tarball from a set of files, it uses the built-in tar-fs functionality to do this, rather than calling `tar.pack()` to pack the cwd and then adding files to it.

Tar-fs docs might be useful for reference here: https://github.com/mafintosh/tar-fs/tree/v1.12.0#usage