### PR TITLE
Fix README about container.exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,16 +191,18 @@ which allows for cleaner interactions with commands that work with stdin and std
 
 ```js
 docker.createContainer({Tty: false, /*... other options */}, function(err, container) {
-  container.exec({Cmd: ['shasum', '-'], AttachStdin: true, AttachStdout: true}, function(err, exec) {
-    exec.start({hijack: true, stdin: true}, function(err, stream) {
-      // shasum can't finish until after its stdin has been closed, telling it that it has
-      // read all the bytes it needs to sum. Without a socket upgrade, there is no way to
-      // close the write-side of the stream without also closing the read-side!
-      fs.createReadStream('node-v5.1.0.tgz', 'binary').pipe(stream);
+  container.start(function(err) {
+    container.exec({Cmd: ['shasum', '-'], AttachStdin: true, AttachStdout: true}, function(err, exec) {
+      exec.start({hijack: true, stdin: true}, function(err, stream) {
+        // shasum can't finish until after its stdin has been closed, telling it that it has
+        // read all the bytes it needs to sum. Without a socket upgrade, there is no way to
+        // close the write-side of the stream without also closing the read-side!
+        fs.createReadStream('node-v5.1.0.tgz', 'binary').pipe(stream.output);
 
-      // Fortunately, we have a regular TCP socket now, so when the readstream finishes and closes our
-      // stream, it is still open for reading and we will still get our results :-)
-      docker.modem.demuxStream(stream, process.stdout, process.stderr);
+        // Fortunately, we have a regular TCP socket now, so when the readstream finishes and closes our
+        // stream, it is still open for reading and we will still get our results :-)
+        docker.modem.demuxStream(stream.output, process.stdout, process.stderr);
+      });
     });
   });
 });


### PR DESCRIPTION
1. container must be started before creating execution
2. callback of exec.start is not actually stream, but stream.output is.