### PR TITLE
Issue #447 authconfig for searchImages() call

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -1169,6 +1169,7 @@ Docker.prototype.searchImages = function(opts, callback) {
     path: '/images/search?',
     method: 'GET',
     options: opts,
+    authconfig: opts.authconfig,
     statusCodes: {
       200: true,
       500: 'server error'


### PR DESCRIPTION
This resolves #447 by adding an authconfig for search call in Dockerode.