### PR TITLE
Add support for `Container#wait(options)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ container.attach({
 - container.kill(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerKill)
 - container.resize(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerResize)
 - container.attach(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerAttach)
-- container.wait() - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerWait)
+- container.wait(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerWait)
 - container.remove(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerDelete)
 - container.getArchive(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerArchive)
 - container.infoArchive(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerArchiveInfo)

--- a/lib/container.js
+++ b/lib/container.js
@@ -31,7 +31,8 @@ var Container = function(modem, id) {
     getArchive: {},
     infoArchive: {},
     putArchive: {},
-    update: {}
+    update: {},
+    wait: {}
   };
 };
 
@@ -754,10 +755,13 @@ Container.prototype.attach = function(opts, callback) {
 
 /**
  * Waits for a container to end.
+ * @param  {[type]}   opts     Container wait options, like condition. (optional)
  * @param  {Function} callback Callback
  */
-Container.prototype.wait = function(callback) {
+Container.prototype.wait = function(opts, callback) {
   var self = this;
+  var args = util.processArgs(opts, callback, this.defaultOptions.wait);
+
   var optsf = {
     path: '/containers/' + this.id + '/wait',
     method: 'POST',
@@ -766,7 +770,8 @@ Container.prototype.wait = function(callback) {
       400: 'bad parameter',
       404: 'no such container',
       500: 'server error'
-    }
+    },
+    options: args.opts
   };
 
   if(callback === undefined) {


### PR DESCRIPTION
- Adds support for the `condition` option to `Container#wait()` as described in docker's [`POST /containers/{id}/wait` endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ContainerWait). 