### PR TITLE
documentation fix: stream.output was undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,11 @@ docker.createContainer({Tty: false, /*... other options */}, function(err, conta
         // shasum can't finish until after its stdin has been closed, telling it that it has
         // read all the bytes it needs to sum. Without a socket upgrade, there is no way to
         // close the write-side of the stream without also closing the read-side!
-        fs.createReadStream('node-v5.1.0.tgz', 'binary').pipe(stream.output);
+        fs.createReadStream('node-v5.1.0.tgz', 'binary').pipe(stream);
 
         // Fortunately, we have a regular TCP socket now, so when the readstream finishes and closes our
         // stream, it is still open for reading and we will still get our results :-)
-        docker.modem.demuxStream(stream.output, process.stdout, process.stderr);
+        docker.modem.demuxStream(stream, process.stdout, process.stderr);
       });
     });
   });


### PR DESCRIPTION
correcting the hijack example in the documentation