### PR TITLE
Added default tag 'latest' to pull method to be more in line with Docker CLI

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -1367,7 +1367,7 @@ Docker.prototype.pull = function(repoTag, opts, callback, auth) {
 
   var imageSrc = util.parseRepositoryTag(repoTag);
   args.opts.fromImage = imageSrc.repository;
-  args.opts.tag = imageSrc.tag;
+  args.opts.tag = imageSrc.tag || 'latest';
 
   var argsf = [args.opts, args.callback];
   if (auth) {


### PR DESCRIPTION
I found that dockerode's pull method doesn't use the default tag `latest` when no tag is given. This seemed to result in Docker downloading a bunch of images when pull was used without a tag, while in reality the user probably only wanted the latest image. It's also different from Docker CLI since that does use `latest` as the default tag when none is given.

This change modifies the pull method to use the default tag `latest` when none is given