### PR TITLE
Change the value of a resolved `exec()` call to be a stream

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -47,7 +47,7 @@ Exec.prototype.start = function(opts, callback) {
           return reject(err);
         }
         self.output = data;
-        resolve(self);
+        resolve(data);
       });
     });
   } else {

--- a/test/container.js
+++ b/test/container.js
@@ -607,6 +607,28 @@ describe("#container", function() {
       container.exec(options, handler);
     });
 
+    it("should run resolve exec promise with a stream", function(done) {
+      this.timeout(20000);
+      var options = {
+        Cmd: ["echo", "'foo'"]
+      };
+
+      var container = docker.getContainer(testContainer);
+
+      function handler(err, exec) {
+        expect(err).to.be.null;
+
+        exec.start()
+          .then(stream => {
+            expect(stream.pipe).to.be.ok;
+            done();
+          })
+          .catch(done);
+      }
+
+      container.exec(options, handler);
+    });
+
     it("should allow exec stream hijacking on a container", function(done) {
       this.timeout(20000);
       var options = {


### PR DESCRIPTION
Resolves #529