### PR TITLE
importImage: fixed default options

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -172,8 +172,11 @@ Docker.prototype.importImage = function(file, opts, callback) {
   var self = this;
   if (!callback && typeof opts === 'function') {
     callback = opts;
-    opts = {};
+    opts = undefined;
   }
+  
+  if (!opts)
+    opts = {};
 
   opts.fromSrc = '-';
 


### PR DESCRIPTION
fixed `Cannot read property 'fromSrc' of undefined` exception when calling `importImage(path)`