### PR TITLE
Add verbose option to network inspect

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -17,21 +17,22 @@ Network.prototype[require('util').inspect.custom] = function() { return this; };
  * @param  {Function} callback Callback, if specified Docker will be queried.
  * @return {Object}            Id only if callback isn't specified.
  */
-Network.prototype.inspect = function(callback) {
+Network.prototype.inspect = function(opts, callback) {
   var self = this;
+  var args = util.processArgs(opts, callback);
 
   var opts = {
-    path: '/networks/' + this.id,
+    path: '/networks/' + this.id + '?',
     method: 'GET',
     statusCodes: {
       200: true,
       404: 'no such network',
       500: 'server error'
-    }
+    },
+    options: args.opts
   };
 
-
-  if(callback === undefined) {
+  if(args.callback === undefined) {
     return new this.modem.Promise(function(resolve, reject) {
       self.modem.dial(opts, function(err, data) {
         if (err) {
@@ -42,7 +43,7 @@ Network.prototype.inspect = function(callback) {
     });
   } else {
     this.modem.dial(opts, function(err, data) {
-      callback(err, data);
+      args.callback(err, data);
     });
   }
 };

--- a/test/networks.js
+++ b/test/networks.js
@@ -84,11 +84,24 @@ describe("#networks", function() {
       function handler(err, data) {
         expect(err).to.be.null;
         expect(data).to.be.ok;
-        expect(data.Containers).to.not.be.null;
+        expect(data.Containers).to.be.ok;
         done();
       }
 
       network.inspect(handler);
+    });
+
+    it("should inspect a network verbosely when verbose: true", function(done) {
+      var network = testNetwork;
+
+      function handler(err, data) {
+        expect(err).to.be.null;
+        expect(data).to.be.ok;
+        expect(data.Containers).to.be.ok;
+        done();
+      }
+
+      network.inspect({ verbose: true }, handler);
     });
   });
 


### PR DESCRIPTION
As described [here](https://docs.docker.com/engine/reference/commandline/network_inspect/).

The verbose flag provides valuable information when using an overlay network in a swarm environment. Currently it is impossible to access service task information using dockerode.

I'm not really sure how to test for the success of a verbose inspect, without setting up a whole swarm environment.