### PR TITLE
getImages added to docker

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -487,6 +487,43 @@ Docker.prototype.listImages = function(opts, callback) {
 };
 
 /**
+ * Get images
+ * @param {Object}   opts     Options (optional)
+ * @param {Function} callback Callback
+ */
+Docker.prototype.getImages = function(opts, callback) {
+  var self = this;
+  var args = util.processArgs(opts, callback);
+
+  var optsf = {
+    path: '/images/get?',
+    method: 'GET',
+    options: args.opts,
+    isStream: true,
+    statusCodes: {
+      200: true,
+      400: 'bad parameter',
+      500: 'server error'
+    }
+  };
+
+  if (args.callback === undefined) {
+    return new this.modem.Promise(function(resolve, reject) {
+      self.modem.dial(optsf, function(err, data) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(data);
+      });
+    });
+  } else {
+    this.modem.dial(optsf, function(err, data) {
+      args.callback(err, data);
+    });
+  }
+};
+
+/**
  * Lists Services
  * @param {Object} opts
  * @param {Function} callback Callback


### PR DESCRIPTION
Added endpoint for [/images/get](https://docs.docker.com/engine/api/v1.40/#operation/ImageGetAll)

This was also requested in issue #470 

