### PR TITLE
Fix pruneBuilder callback check

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -886,7 +886,7 @@ Docker.prototype.pruneBuilder = function(callback) {
     }
   };
 
-  if (args.callback === undefined) {
+  if (callback === undefined) {
     return new this.modem.Promise(function(resolve, reject) {
       self.modem.dial(optsf, function(err, data) {
         if (err) {


### PR DESCRIPTION
A small fix for `pruneBuilder` function that currently fails because it tries to use non-existent `args` variable.