### PR TITLE
Disabling auto-pack when building image

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -248,7 +248,6 @@ Docker.prototype.checkAuth = function(opts, callback) {
 Docker.prototype.buildImage = function(file, opts, callback) {
   var self = this;
   var content;
-  var pack;
 
   if (!callback && typeof opts === 'function') {
     callback = opts;
@@ -298,7 +297,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
   }
 
   if (file && file.context) {
-    pack = tar.pack(file.context, {
+    var pack = tar.pack(file.context, {
       entries: file.src
     });
     return build(pack.pipe(zlib.createGzip()));

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -248,7 +248,7 @@ Docker.prototype.checkAuth = function(opts, callback) {
 Docker.prototype.buildImage = function(file, opts, callback) {
   var self = this;
   var content;
-  var pack = tar.pack();
+  var pack;
 
   if (!callback && typeof opts === 'function') {
     callback = opts;


### PR DESCRIPTION
Tar-fs packs files in current directory by default if nothing is specified as first argument. Thus, when initializing `pack` at the start of the `buildImage` method, it started packing the entire current directory.
In my case, I package my app with Nexe and it tried to pack the entire virtual directory where my code was stored to be ran by Node and crashed because it couldn't find real files in it.
In other cases, this is just an unneeded waste of time whether the context is specified or not.