### PR TITLE
Added .dockerignore support for build

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -14,7 +14,11 @@ var EventEmitter = require('events').EventEmitter,
   Node = require('./node'),
   Exec = require('./exec'),
   util = require('./util'),
-  extend = util.extend;
+  extend = util.extend,
+  path = require('path'),
+  extend = util.extend,
+  ignore = require('@balena/dockerignore'),
+  fs = require('fs');
 
 var Docker = function(opts) {
   if (!(this instanceof Docker)) return new Docker(opts);
@@ -297,8 +301,16 @@ Docker.prototype.buildImage = function(file, opts, callback) {
   }
 
   if (file && file.context) {
+    let entries = file.src
+
+    const dockerignorePath = path.join(file.context, '.dockerignore')
+    if (fs.existsSync(dockerignorePath)) {
+      const dockerIgnore = ignore({ ignorecase: false }).add(fs.readFileSync(dockerignorePath).toString())
+      entries = entries.filter(dockerIgnore.createFilter())
+    }
+
     var pack = tar.pack(file.context, {
-      entries: file.src
+      entries: entries
     });
     return build(pack.pipe(zlib.createGzip()));
   } else {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -306,7 +306,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
     const dockerignorePath = path.join(file.context, '.dockerignore')
     if (fs.existsSync(dockerignorePath)) {
       const dockerIgnore = ignore({ ignorecase: false }).add(fs.readFileSync(dockerignorePath).toString())
-      entries = entries.filter(dockerIgnore.createFilter())
+      entries = (entries || []).filter(dockerIgnore.createFilter())
     }
 
     var pack = tar.pack(file.context, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docker.io"
   ],
   "dependencies": {
+    "@balena/dockerignore": "^1.0.2",
     "docker-modem": "^2.1.0",
     "tar-fs": "~2.0.1"
   },

--- a/test/.dockerignore
+++ b/test/.dockerignore
@@ -1,0 +1,1 @@
+test.tar

--- a/test/docker.js
+++ b/test/docker.js
@@ -130,6 +130,28 @@ describe("#docker", function() {
         src: ['Dockerfile']
       }, {}, handler);
     });
+
+    it("should build image from multiple files while respecting the dockerignore file", function(done) {
+      this.timeout(60000);
+
+      function handler(err, stream) {
+        expect(err).to.be.null;
+        expect(stream).to.be.ok;
+
+        stream.pipe(process.stdout, {
+          end: true
+        });
+
+        stream.on('end', function() {
+          done();
+        });
+      }
+
+      docker.buildImage({
+        context: __dirname,
+        src: ['Dockerfile', '.dockerignore', 'test.tar']
+      }, {}, handler);
+    });
   });
 
 


### PR DESCRIPTION
Fixes #545 

Using [@balenaa/dockerignore](https://github.com/balena-io-modules/dockerignore) to respect `.dockerignore` rules when building a new image from source