### PR TITLE
Add 409 to status codes for /containers/:id/exec

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -492,6 +492,7 @@ Container.prototype.exec = function(opts, callback) {
       200: true, // unofficial, but proxies may return it
       201: true,
       404: 'no such container',
+      409: 'container stopped/paused',
       500: 'server error'
     },
     options: args.opts


### PR DESCRIPTION
The `POST /container/:id/exec` endpoint can respond with with a 409 status code if the container isn't running (docs [here](https://docs.docker.com/engine/api/v1.37/#operation/ContainerExec)), but that isn't included as a recognized code so the `Error` that gets thrown has an empty `reason` property and the message is less descriptive than it could be.

I used the same `reason` as is used for 409s when trying to start an `Exec` for a container that isn't running.