### PR TITLE
Fix docker.buildImage() mutating src array due to tar-fs behaviour

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -303,7 +303,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
 
   if (file && file.context) {
     var pack = tar.pack(file.context, {
-      entries: file.src
+      entries: file.src.slice()
     });
     return build(pack.pipe(zlib.createGzip()));
   } else {

--- a/test/docker.js
+++ b/test/docker.js
@@ -37,7 +37,7 @@ describe("#docker", function() {
         cert,
         key
       });
-  
+
       assert.strictEqual(ca, d.modem.ca);
       assert.strictEqual(cert, d.modem.cert);
       assert.strictEqual(key, d.modem.key);
@@ -129,6 +129,31 @@ describe("#docker", function() {
         context: __dirname,
         src: ['Dockerfile']
       }, {}, handler);
+    });
+
+    it("should not mutate src array", function(done) {
+      this.timeout(60000);
+
+      function handler(err, stream) {
+        expect(err).to.be.null;
+        expect(stream).to.be.ok;
+
+        stream.pipe(process.stdout, {
+          end: true
+        });
+
+        stream.on('end', function() {
+          done();
+        });
+      }
+
+      const src = ['Dockerfile']
+      docker.buildImage({
+        context: __dirname,
+        src: src
+      }, {}, handler);
+
+      expect(src).to.contain('Dockerfile');
     });
   });
 


### PR DESCRIPTION
Thanks for the great lib!

#### What happened
Im writing some utils to build images, making use of dockerode's `buildImage()`. When testing my util, I was constantly running into a `500 error: Dockerfile not found`. Was super confused by this since I can clearly see the Dockerfile sitting in the `context` directory. It wasn't a file permission issue either. 

After digging around, I noticed the src array was being cleared after passing it into `buildImage()` due to its use of tar-fs's `statAll()` which in its current implementation mutates its `entries` array parameter. A PR has been opened for it but seems to have gone stale: https://github.com/mafintosh/tar-fs/pull/78, hence I'm opening the fix here instead to prevent others from facing this gotcha.

#### Details
dockerode.buildImage
https://github.com/apocas/dockerode/blob/42e6623e0b484fc864277cb9a1884ce1fc68086c/lib/docker.js#L304-L307

tar-fs.statAll mutates the `entries` array
<img width="513" alt="image" src="https://user-images.githubusercontent.com/31790206/182034579-2fcc0c4c-96ca-4e9a-9b03-b25d9495d6c3.png">
https://github.com/mafintosh/tar-fs/blob/7ec11cb27f93948193770f32b4d820e2e7195715/index.js#L21-L26