### PR TITLE
Remove promise nesting in buildImage() when no callback

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -283,12 +283,8 @@ Docker.prototype.buildImage = function(file, opts, callback) {
   }
 
   if (callback === undefined) {
-    const prepareCtxPromise = new self.modem.Promise(function(resolve, _) {
-      util.prepareBuildContext(file, resolve)
-    });
-
-    return prepareCtxPromise.then((ctx)=> {
-      return new self.modem.Promise(function(resolve, reject) {
+    return new self.modem.Promise(function(resolve, reject) {
+      util.prepareBuildContext(file, (ctx) => {
         optsf.file = ctx;
         self.modem.dial(optsf, function(err, data) {
           if (err) {
@@ -297,7 +293,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
           resolve(data);
         });
       });
-    })
+    });
   } else {
     util.prepareBuildContext(file, (ctx) => {
       optsf.file = ctx;

--- a/test/docker.js
+++ b/test/docker.js
@@ -90,6 +90,23 @@ describe("#docker", function() {
       docker.buildImage('./test/test.tar', {}, handler);
     });
 
+    it("should build image from file using Promise", function(done) {
+      this.timeout(60000);
+
+      docker.buildImage('./test/test.tar', {}).then((stream) => {
+        expect(stream).to.be.ok;
+
+        stream.pipe(process.stdout, {
+          end: true
+        });
+
+        stream.on('end', function() {
+          done();
+        });
+      })
+      .catch(error => done(error))
+    });
+
     it("should build image from readable stream", function(done) {
       this.timeout(60000);
 
@@ -175,7 +192,27 @@ describe("#docker", function() {
         src: ['Dockerfile', '.dockerignore', 'test.tar']
       }, {}, handler);
     });
-    
+
+    it("should build image from multiple files while respecting the dockerignore file via Promise", function(done) {
+      this.timeout(60000);
+
+      docker.buildImage({
+        context: __dirname,
+        src: ['Dockerfile', '.dockerignore', 'test.tar']
+      }, {}).then((stream) => {
+        expect(stream).to.be.ok;
+
+        stream.pipe(process.stdout, {
+          end: true
+        });
+
+        stream.on('end', function() {
+          done();
+        });
+      })
+      .catch(error => done(error))
+    });
+
     it("should not mutate src array", function(done) {
       this.timeout(60000);
 


### PR DESCRIPTION
Uses a single Promise as in v3.3.3, but maintains the asynchronous approach to `.dockerignore` processing added in v3.3.4.

Also added unit tests for the no-callback, Promise based path.

Fixes #696 