### PR TITLE
Allow passing a Modem instance directly

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -27,7 +27,11 @@ var Docker = function(opts) {
     }
   }
 
-  this.modem = new Modem(opts);
+  if (opts && opts.modem) {
+    this.modem = opts.modem;
+  } else {
+    this.modem = new Modem(opts);
+  }
   this.modem.Promise = plibrary;
 };
 


### PR DESCRIPTION
This would allow calling Docker API via custom transports, e. g. [Portainer's authenticating proxy](https://app.swaggerhub.com/apis-docs/portainer/portainer-ce/2.16.1) (see section “Execute Docker requests”). Of course, we could add just those to the docker-modem itself, but I think a modular approach would be better here, and not really more verbose:

```js
const PortainerModem = require("@aedge/docker-modem-portainer");  // not implemented yet
const Docker = require("dockerode");

const docker = new Docker({
  modem: new PortainerModem({
    apiEndpoint: "https://portainer.lvh.me/api",
    token: "eyJhbGciOiJ...",
  }),
});
```
