### PR TITLE
fix: node inspect is not using abort signal

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -25,7 +25,7 @@ Node.prototype.inspect = function(opts, callback) {
   var optsf = {
     path: '/nodes/' + this.id,
     method: 'GET',
-    abortSignal: args.abortSignal,
+    abortSignal: args.opts.abortSignal,
     statusCodes: {
       200: true,
       404: 'no such node',


### PR DESCRIPTION
This is the only location I found in the repo where we get `abortSignal` from `args` instead of `args.opts` (out of 101 locations) which ends up being undefined and so ignored.