### PR TITLE
Bugfix config remove

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -103,7 +103,7 @@ Config.prototype.remove = function(opts, callback) {
   var optsf = {
     path: '/configs/' + this.id,
     method: 'DELETE',
-    abortSignal: opts.abortSignal,
+    abortSignal: args.opts.abortSignal,
     statusCodes: {
       200: true,
       204: true,


### PR DESCRIPTION
It seems like this is just a simple mistake.

create, update and list, all gets their abortSignal from the args.

closes #739 