### PR TITLE
error managed in run_stdin example

### DIFF
--- a/examples/run_stdin.js
+++ b/examples/run_stdin.js
@@ -31,6 +31,9 @@ var previousKey,
     CTRL_Q = '\u0011';
 
 function handler(err, container) {
+  //Check error and thow it 
+  if(err) throw new Error(err);
+
   var attach_opts = {stream: true, stdin: true, stdout: true, stderr: true};
 
   container.attach(attach_opts, function handler(err, stream) {


### PR DESCRIPTION
In **run_stdin** example error not managed, so when run this example and if image not found locally it give error but it show different error and create confusion. So i managed  error so it will give **Unable to find image** error.