### PR TITLE
POC: BuildKit support

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -12,6 +12,7 @@ var EventEmitter = require('events').EventEmitter,
   Node = require('./node'),
   Exec = require('./exec'),
   util = require('./util'),
+  withSession = require('./session');
   extend = util.extend;
 
 var Docker = function(opts) {
@@ -287,25 +288,46 @@ Docker.prototype.buildImage = function(file, opts, callback) {
     }
   }
 
-  if (callback === undefined) {
-    return new self.modem.Promise(function(resolve, reject) {
-      util.prepareBuildContext(file, (ctx) => {
-        optsf.file = ctx;
-        self.modem.dial(optsf, function(err, data) {
-          if (err) {
-            return reject(err);
+  function dial(callback) {
+    util.prepareBuildContext(file, (ctx) => {
+      optsf.file = ctx;
+      self.modem.dial(optsf, callback);
+    });
+  }
+
+  function dialWithSession(callback) {
+    if (opts?.version === "2") {
+      withSession(self, optsf.authconfig,(err, sessionId, done) => {
+        if (err) {
+          return callback(err);
+        }
+
+        optsf.options.session = sessionId;
+
+        dial((err, data) => {
+          callback(err, data);
+
+          if (data) {
+            data.on("end", done);
           }
-          resolve(data);
         });
+      });
+    } else {
+      dial(null, callback);
+    }
+  }
+
+  if (callback === undefined) {
+    return new self.modem.Promise(function (resolve, reject) {
+      dialWithSession(function (err, data) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(data);
       });
     });
   } else {
-    util.prepareBuildContext(file, (ctx) => {
-      optsf.file = ctx;
-      self.modem.dial(optsf, function(err, data) {
-        callback(err, data);
-      });
-    })
+    dialWithSession(callback);
   }
 };
 

--- a/lib/proto/auth.proto
+++ b/lib/proto/auth.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package moby.filesync.v1;
+
+option go_package = "auth";
+
+service Auth{
+	rpc Credentials(CredentialsRequest) returns (CredentialsResponse);
+	rpc FetchToken(FetchTokenRequest) returns (FetchTokenResponse);
+	rpc GetTokenAuthority(GetTokenAuthorityRequest) returns (GetTokenAuthorityResponse);
+	rpc VerifyTokenAuthority(VerifyTokenAuthorityRequest) returns (VerifyTokenAuthorityResponse);
+}
+
+message CredentialsRequest {
+	string Host = 1;
+}
+
+message CredentialsResponse {
+	string Username = 1;
+	string Secret = 2;
+}
+
+message FetchTokenRequest {
+	string ClientID = 1;
+	string Host = 2;
+	string Realm = 3;
+	string Service = 4;
+	repeated string Scopes = 5;
+}
+
+message FetchTokenResponse {
+	string Token = 1;
+	int64 ExpiresIn = 2; // seconds
+	int64 IssuedAt = 3; // timestamp
+}
+
+message GetTokenAuthorityRequest {
+	string Host = 1;
+	bytes Salt = 2;
+}
+
+message GetTokenAuthorityResponse {
+	bytes PublicKey = 1;
+}
+
+message VerifyTokenAuthorityRequest {
+	string Host = 1;
+	bytes Payload = 2;
+	bytes Salt = 3;
+}
+
+message VerifyTokenAuthorityResponse {
+	bytes Signed = 1;
+}

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,0 +1,63 @@
+var grpc = require("@grpc/grpc-js"),
+  protoLoader = require("@grpc/proto-loader"),
+  path = require("path"),
+  uuid = require("uuid").v4;
+
+function withSession(docker, auth, handler) {
+  const sessionId = uuid();
+
+  const opts = {
+    method: "POST",
+    path: "/session",
+    hijack: true,
+    headers: {
+      Upgrade: "h2c",
+      "X-Docker-Expose-Session-Uuid": sessionId,
+      "X-Docker-Expose-Session-Name": "testcontainers",
+    },
+    statusCodes: {
+      200: true,
+      500: "server error",
+    },
+  };
+
+  docker.modem.dial(opts, function (err, socket) {
+    if (err) {
+      return handler(err, null, () => undefined);
+    }
+
+    const server = new grpc.Server();
+    const creds = grpc.ServerCredentials.createInsecure();
+    const injector = server.createConnectionInjector(creds);
+    injector.injectConnection(socket);
+
+    const pkg = protoLoader.loadSync(
+      path.resolve(__dirname, "proto", "auth.proto")
+    );
+    const service = grpc.loadPackageDefinition(pkg);
+
+    server.addService(service.moby.filesync.v1.Auth.service, {
+      Credentials({ request }, callback) {
+        // We probably want to have the possibility to pass credentials per
+        // hots. The correct one could be returned based on `request.Host`
+        if (auth) {
+          callback(null, {
+            Username: auth.username,
+            Secret: auth.password,
+          });
+        } else {
+          callback(null, {});
+        }
+      },
+    });
+
+    function done() {
+      server.forceShutdown();
+      socket.end();
+    }
+
+    handler(null, sessionId, done);
+  });
+}
+
+module.exports = withSession;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "@grpc/grpc-js": "file:../grpc-node/packages/grpc-js",
+        "@grpc/grpc-js": "^1.11.1",
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "file:../docker-modem",
         "protobufjs": "^7.3.2",
@@ -44,58 +44,22 @@
         "node": ">= 8.0"
       }
     },
-    "../grpc-node/packages/grpc-js": {
-      "name": "@grpc/grpc-js",
-      "version": "1.10.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
-        "@js-sdsl/ordered-map": "^4.4.2"
-      },
-      "devDependencies": {
-        "@grpc/proto-loader": "file:../proto-loader",
-        "@types/gulp": "^4.0.17",
-        "@types/gulp-mocha": "0.0.37",
-        "@types/lodash": "^4.14.202",
-        "@types/mocha": "^10.0.6",
-        "@types/ncp": "^2.0.8",
-        "@types/node": ">=20.11.20",
-        "@types/pify": "^5.0.4",
-        "@types/semver": "^7.5.8",
-        "@typescript-eslint/eslint-plugin": "^7.1.0",
-        "@typescript-eslint/parser": "^7.1.0",
-        "@typescript-eslint/typescript-estree": "^7.1.0",
-        "clang-format": "^1.8.0",
-        "eslint": "^8.42.0",
-        "eslint-config-prettier": "^8.8.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.2.1",
-        "execa": "^2.0.3",
-        "gulp": "^4.0.2",
-        "gulp-mocha": "^6.0.0",
-        "lodash": "^4.17.21",
-        "madge": "^5.0.1",
-        "mocha-jenkins-reporter": "^0.4.1",
-        "ncp": "^2.0.0",
-        "pify": "^4.0.1",
-        "prettier": "^2.8.8",
-        "rimraf": "^3.0.2",
-        "semver": "^7.6.0",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.3.3"
-      },
-      "engines": {
-        "node": ">=12.10.0"
-      }
-    },
     "node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
     },
     "node_modules/@grpc/grpc-js": {
-      "resolved": "../grpc-node/packages/grpc-js",
-      "link": true
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
+      "integrity": "sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.7.13",
@@ -150,6 +114,15 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,21 @@
 {
   "name": "dockerode",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dockerode",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "docker-modem": "^5.0.3",
-        "tar-fs": "~2.0.1"
+        "@grpc/grpc-js": "file:../grpc-node/packages/grpc-js",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "file:../docker-modem",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "~2.0.1",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "bluebird": "^3.7.0",
@@ -23,10 +27,192 @@
         "node": ">= 8.0"
       }
     },
+    "../docker-modem": {
+      "version": "5.0.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "devDependencies": {
+        "chai": "~4.2.0",
+        "mocha": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "../grpc-node/packages/grpc-js": {
+      "name": "@grpc/grpc-js",
+      "version": "1.10.8",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "devDependencies": {
+        "@grpc/proto-loader": "file:../proto-loader",
+        "@types/gulp": "^4.0.17",
+        "@types/gulp-mocha": "0.0.37",
+        "@types/lodash": "^4.14.202",
+        "@types/mocha": "^10.0.6",
+        "@types/ncp": "^2.0.8",
+        "@types/node": ">=20.11.20",
+        "@types/pify": "^5.0.4",
+        "@types/semver": "^7.5.8",
+        "@typescript-eslint/eslint-plugin": "^7.1.0",
+        "@typescript-eslint/parser": "^7.1.0",
+        "@typescript-eslint/typescript-estree": "^7.1.0",
+        "clang-format": "^1.8.0",
+        "eslint": "^8.42.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "execa": "^2.0.3",
+        "gulp": "^4.0.2",
+        "gulp-mocha": "^6.0.0",
+        "lodash": "^4.17.21",
+        "madge": "^5.0.1",
+        "mocha-jenkins-reporter": "^0.4.1",
+        "ncp": "^2.0.0",
+        "pify": "^4.0.1",
+        "prettier": "^2.8.8",
+        "rimraf": "^3.0.2",
+        "semver": "^7.6.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
     "node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
+    },
+    "node_modules/@grpc/grpc-js": {
+      "resolved": "../grpc-node/packages/grpc-js",
+      "link": true
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -41,7 +227,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -50,7 +235,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -79,14 +263,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -121,14 +297,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -203,15 +371,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buildcheck": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
-      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/camelcase": {
@@ -330,7 +489,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -341,8 +499,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -350,24 +507,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/cpu-features": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
-      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "~0.0.6",
-        "nan": "^2.17.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -414,24 +558,13 @@
       }
     },
     "node_modules/docker-modem": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.3.tgz",
-      "integrity": "sha512-89zhop5YVhcPEt5FpUFGr3cDyceGhq/F9J+ZndQ4KfqNvfbJpPMfgeixFgUj5OjCYAboElqODxY5Z1EBsSa6sg==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "readable-stream": "^3.5.0",
-        "split-ca": "^1.0.1",
-        "ssh2": "^1.15.0"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
+      "resolved": "../docker-modem",
+      "link": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -445,7 +578,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -528,7 +660,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -673,7 +804,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -747,6 +877,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -762,6 +897,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -838,13 +978,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
-      "optional": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -944,6 +1079,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -991,7 +1149,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1015,11 +1172,6 @@
         }
       ]
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -1027,28 +1179,6 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/split-ca": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
-      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
-    },
-    "node_modules/ssh2": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
-      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "asn1": "^0.2.6",
-        "bcrypt-pbkdf": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      },
-      "optionalDependencies": {
-        "cpu-features": "~0.0.9",
-        "nan": "^2.18.0"
       }
     },
     "node_modules/string_decoder": {
@@ -1063,7 +1193,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1077,7 +1206,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -1150,11 +1278,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -1164,10 +1287,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/workerpool": {
       "version": "6.2.1",
@@ -1179,7 +1319,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1201,7 +1340,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
   ],
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
-    "docker-modem": "^5.0.3",
-    "tar-fs": "~2.0.1"
+    "@grpc/grpc-js": "file:../grpc-node/packages/grpc-js",
+    "@grpc/proto-loader": "^0.7.13",
+    "docker-modem": "file:../docker-modem",
+    "protobufjs": "^7.3.2",
+    "tar-fs": "~2.0.1",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "bluebird": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
-    "@grpc/grpc-js": "file:../grpc-node/packages/grpc-js",
+    "@grpc/grpc-js": "^1.11.1",
     "@grpc/proto-loader": "^0.7.13",
     "docker-modem": "file:../docker-modem",
     "protobufjs": "^7.3.2",

--- a/test/buildkit.Dockerfile
+++ b/test/buildkit.Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN --mount=type=cache,target=/test echo test
+
+CMD ["bash"]

--- a/test/docker.js
+++ b/test/docker.js
@@ -237,6 +237,42 @@ describe("#docker", function() {
 
       expect(src).to.contain('Dockerfile');
     });
+
+    it("should build image with buildKit", function (done) {
+      this.timeout(60000);
+      const randomId = Math.random().toString(36).substring(7);
+
+      function handler(err, stream) {
+        expect(err).to.be.null;
+        expect(stream).to.be.ok;
+
+        stream.pipe(process.stdout, {
+          end: true,
+        });
+
+        stream.on("end", function () {
+          docker.getImage(randomId).inspect((err, image) => {
+            expect(err).to.be.null;
+            expect(image).to.exist;
+            done();
+          });
+        });
+      }
+
+      docker.buildImage(
+        {
+          context: __dirname,
+          src: ["buildkit.Dockerfile"],
+        },
+        {
+          dockerfile: "buildkit.Dockerfile",
+          version: "2",
+          t: randomId,
+          pull: "true",
+        },
+        handler
+      );
+    });
   });
 
   describe("#loadImage", function() {


### PR DESCRIPTION
I managed to get BuildKit build to work! It is not perfect yet, but it works most of the time for me.

To do this, dockerode needs to create a gRPC server and serve over a hijacked session connection to the docker backend and attach the sessionId to the build request. Even a gRPC server without any implemented services will do, but it can also be used to return credentials to docker, which is needed when using private Images or Registries.

The are some open todos and problems:
- [ ] Small changes in docker-modem are needed: https://github.com/apocas/docker-modem/pull/173
- [x] A new release of @grpc/grpc-js is needed. The `createConnectionInjector` feature is already in master, but not release yet (https://github.com/grpc/grpc-node/pull/2675). At the moment one has to build @grpc/grpc-js locally (that's why it's linked locally in the package.json for now)
- [ ] Occasionally, without changing anything, I see one of two errors in the build log. I don't know if it's a docker problem or something is wrong in my implementation. I'm happy for any hints.
  - "Error while dialing only one connection allowed"
  - "http2: frame too large" 

Solves #601 