### PR TITLE
Add support for specific .dockerignore files that share the Dockerfile name

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -289,7 +289,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
 
   if (callback === undefined) {
     return new self.modem.Promise(function(resolve, reject) {
-      util.prepareBuildContext(file, (ctx) => {
+      util.prepareBuildContext(file, opts, (ctx) => {
         optsf.file = ctx;
         self.modem.dial(optsf, function(err, data) {
           if (err) {
@@ -300,7 +300,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
       });
     });
   } else {
-    util.prepareBuildContext(file, (ctx) => {
+    util.prepareBuildContext(file, opts, (ctx) => {
       optsf.file = ctx;
       self.modem.dial(optsf, function(err, data) {
         callback(err, data);

--- a/lib/util.js
+++ b/lib/util.js
@@ -76,9 +76,19 @@ module.exports.parseRepositoryTag = function(input) {
 };
 
 
-module.exports.prepareBuildContext = function(file, next) {
+module.exports.prepareBuildContext = function(file, opts, next) {
   if (file && file.context) {
-    fs.readFile(path.join(file.context, '.dockerignore'), (err, data) => {
+    let dockerfilePath = path.join(file.context, 'Dockerfile');
+    if (opts && opts.dockerfile) {
+      dockerfilePath = path.normalize(opts.dockerfile);
+    }
+
+    let dockerignorePath = path.join(file.context, '.dockerignore');
+    if (fs.existsSync(`${dockerfilePath}.dockerignore`)) {
+      dockerignorePath = `${dockerfilePath}.dockerignore`;
+    }
+
+    fs.readFile(dockerignorePath, (err, data) => {
       let ignoreFn;
       let filterFn;
 

--- a/test/fixtures/dockerignore/specific.Dockerfile
+++ b/test/fixtures/dockerignore/specific.Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY . .
+
+CMD ["bash"]

--- a/test/fixtures/dockerignore/specific.Dockerfile.dockerignore
+++ b/test/fixtures/dockerignore/specific.Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+# Ignore dirs
+ignore-dir
+# Ignore blobs
+*.txt


### PR DESCRIPTION
This PR adds support for "specific" `.dockerignore` files which allow you to have a `<name-of-Dockerfile>.dockerignore` in the same directory of the `<name-of-Dockerfile>` to take precedence over the `.dockerignore` in the context directory. Read more details about these types of ignore files [on the Docker docs](https://docs.docker.com/build/building/context/#filename-and-location).