### PR TITLE
Declare 'extend' variable in docker.js

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -13,7 +13,8 @@ var EventEmitter = require('events').EventEmitter,
   Exec = require('./exec'),
   util = require('./util'),
   withSession = require('./session');
-  extend = util.extend;
+
+var extend = util.extend;
 
 var Docker = function(opts) {
   if (!(this instanceof Docker)) return new Docker(opts);

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -12,9 +12,8 @@ var EventEmitter = require('events').EventEmitter,
   Node = require('./node'),
   Exec = require('./exec'),
   util = require('./util'),
-  withSession = require('./session');
-
-var extend = util.extend;
+  withSession = require('./session'),
+  extend = util.extend;
 
 var Docker = function(opts) {
   if (!(this instanceof Docker)) return new Docker(opts);


### PR DESCRIPTION
This 'extend' variable is not being defined which is causing errors in node v20.