### PR TITLE
Use JSON serialization for cachefrom option

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -286,6 +286,10 @@ Docker.prototype.buildImage = function(file, opts, callback) {
       optsf.authconfig = optsf.options.authconfig;
       delete optsf.options.authconfig;
     }
+
+    if (opts.cachefrom && Array.isArray(opts.cachefrom)) {
+      optsf.options.cachefrom = JSON.stringify(opts.cachefrom);
+    }
   }
 
   function dial(callback) {

--- a/test/docker.js
+++ b/test/docker.js
@@ -149,6 +149,28 @@ describe("#docker", function() {
       }, { t: 'multiple-files' }, handler);
     });
 
+    it("should build image from multiple files using cache", function(done) {
+      this.timeout(60000);
+
+      function handler(err, stream) {
+        expect(err).to.be.null;
+        expect(stream).to.be.ok;
+
+        stream.pipe(process.stdout, {
+          end: true
+        });
+
+        stream.on('end', function() {
+          done();
+        });
+      }
+
+      docker.buildImage({
+        context: __dirname,
+        src: ['Dockerfile']
+      }, { t: 'multiple-files-cachefrom', 'cachefrom': ['ubuntu:latest'] }, handler);
+    });
+
     it("should build image from multiple files while respecting the .dockerignore file", function(done) {
       this.timeout(60000);
 


### PR DESCRIPTION
Docker [ImageBuild](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Image/operation/ImageBuild) endpoint requires that the `cachefrom` option is a "JSON serialized array". This requirement seems to be an exception to the way arrays are consumed by the API (usually querystring serialized).

This change is needed after https://github.com/apocas/docker-modem/pull/181 that makes querystring serialized arrays the default.

This commit adds an exception for this option on `Docker.buildImage`.

Change-type: patch
Closes: #792