### PR TITLE
Update image.inspect method to accept options

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ Amazing entities that [sponsor](https://github.com/sponsors/apocas) my open-sour
 
 ### Image
 
-- image.inspect() - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ImageInspect)
+- image.inspect(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.48/#tag/Image/operation/ImageInspect)
 - image.history() - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ImageHistory)
 - image.push(options, callback, auth) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ImagePush)
 - image.tag(options) - [Docker API Endpoint](https://docs.docker.com/engine/api/v1.37/#operation/ImageTag)

--- a/lib/image.js
+++ b/lib/image.js
@@ -14,15 +14,18 @@ Image.prototype[require('util').inspect.custom] = function() { return this; };
 
 /**
  * Inspect
+ * @param  {Object} opts       Inspect options, only 'manifests' (optional)
  * @param  {Function} callback Callback, if specified Docker will be queried.
  * @return {Object}            Name only if callback isn't specified.
  */
-Image.prototype.inspect = function(callback) {
+Image.prototype.inspect = function(opts, callback) {
+  var args = util.processArgs(opts, callback);
   var self = this;
 
   var opts = {
     path: '/images/' + this.name + '/json',
     method: 'GET',
+    options: args.opts,
     statusCodes: {
       200: true,
       404: 'no such image',

--- a/test/docker.js
+++ b/test/docker.js
@@ -273,7 +273,7 @@ describe("#docker", function() {
         });
 
         stream.on("end", function () {
-          docker.getImage(randomId).inspect((err, image) => {
+          docker.getImage(randomId).inspect(undefined, (err, image) => {
             expect(err).to.be.null;
             expect(image).to.exist;
             done();

--- a/test/image.js
+++ b/test/image.js
@@ -17,7 +17,7 @@ describe("#image", function() {
         done();
       }
 
-      image.inspect(handler);
+      image.inspect(undefined, handler);
     });
 
     it("should inspect an image with manifest", function (done) {

--- a/test/image.js
+++ b/test/image.js
@@ -19,6 +19,18 @@ describe("#image", function() {
 
       image.inspect(handler);
     });
+
+    it("should inspect an image with manifest", function (done) {
+      var image = docker.getImage(testImage);
+
+      function handler(err, data) {
+        expect(err).to.be.null;
+        expect(data).to.be.ok;
+        done();
+      }
+
+      image.inspect({manifest: 1}, handler);
+    });
   });
 
   describe("#distribution", function() {


### PR DESCRIPTION
- Modify the `image.inspect` method to accept options, allowing for more flexible image inspection, including the ability to specify manifests.
- Update tests to verify the new functionality.
- Update the README to reflect the new functionality