### PR TITLE
Remove use of uuid package

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -1,7 +1,7 @@
 var grpc = require("@grpc/grpc-js"),
   protoLoader = require("@grpc/proto-loader"),
   path = require("path"),
-  uuid = require("uuid").v4;
+  uuid = require("crypto").randomUUID;
 
 function withSession(docker, auth, handler) {
   const sessionId = uuid();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "^5.0.6",
         "protobufjs": "^7.3.2",
-        "tar-fs": "~2.1.2",
-        "uuid": "^10.0.0"
+        "tar-fs": "~2.1.2"
       },
       "devDependencies": {
         "bluebird": "^3.7.0",
@@ -1202,17 +1201,6 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/workerpool": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "@grpc/proto-loader": "^0.7.13",
     "docker-modem": "^5.0.6",
     "protobufjs": "^7.3.2",
-    "tar-fs": "~2.1.2",
-    "uuid": "^10.0.0"
+    "tar-fs": "~2.1.2"
   },
   "devDependencies": {
     "bluebird": "^3.7.0",


### PR DESCRIPTION
`crypto.randomUUID` is supported since Node.js 14.17.0.: https://nodejs.org/api/crypto.html#cryptorandomuuidoptions

The CI pipeline suggests that this library supports Node from 14 onwards (even though v18 will run out of support tomorrow):
https://github.com/apocas/dockerode/blob/3f68f9b943d669bd295ffa7804aa8b971508da43/.github/workflows/main.yml#L14

This might be a breaking change if someone uses Node.js < 14.17. [CI pulls in 14.21.3](https://github.com/apocas/dockerode/actions/runs/14548790979/job/40817513672#step:3:9) as it is specified to use `14.x`.

The package.json has `"engine": "node > 8"`, so I'm not entirely sure which Node.js versions are officially supported. If this project aims to support only the currently supported Node.js versions, this PR is not a breaking change.

The motivation for this change is to reduce download size in general and reduce supply-chain risk. Dockerode is downloaded `1265386` times a week, so about 68,330,844 times a year. uuid@10.tar.gz is `29328 bytes`. So this dependency causes traffic of about 1866 GiB per year (about 1.8TB).