### PR TITLE
Extend getArchive to allow headers to be passed in to the HTTP request.

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -887,12 +887,17 @@ Container.prototype.copy = function(opts, callback) {
 
 /**
  * getArchive
- * @param  {Object}   opts     Archive options, like 'path'
+ * @param  {Object}   opts     Archive options, like 'path'. As a special case,
+ * allows `headers`, which will set the HTTP headers used on the request.
+ * Use this to set `headers: { 'Accept-Encoding': 'gzip' }` to get a gzipped
+ * tar.
  * @param  {Function} callback Callback with stream.
  */
 Container.prototype.getArchive = function(opts, callback) {
   var self = this;
   var args = util.processArgs(opts, callback, this.defaultOptions.getArchive);
+
+  const { headers, ...otherOpts } = args.opts;
 
   var optsf = {
     path: '/containers/' + this.id + '/archive?',
@@ -905,7 +910,8 @@ Container.prototype.getArchive = function(opts, callback) {
       404: 'no such container',
       500: 'server error'
     },
-    options: args.opts
+    options: otherOpts,
+    headers,
   };
 
   if(args.callback === undefined) {


### PR DESCRIPTION
This can be used to get a gzipped tar by passing in Accept-Encoding: gzip.