### PR TITLE
chore: bump tar-fs dependency version to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@grpc/proto-loader": "^0.7.13",
     "docker-modem": "^5.0.6",
     "protobufjs": "^7.3.2",
-    "tar-fs": "~2.1.2",
+    "tar-fs": "~2.1.3",
     "uuid": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Related to #812 

Fix CVE-2025-48387