### PR TITLE
perf(util): remove redundant slice() before filter in prepareBuildContext

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -91,7 +91,7 @@ module.exports.prepareBuildContext = function(file, next) {
         }
       }
 
-      const entries = file.src.slice() || []
+      const entries = file.src || []
 
       const pack = tar.pack(file.context, {
         entries: filterFn ? entries.filter(filterFn) : entries,


### PR DESCRIPTION
`file.src.slice()` always returns a truthy array, so the `|| []` fallback was unreachable dead code. When a `filterFn` is present, `entries.filter()` already allocates a new array, making the prior `.slice()` copy wasteful. Replacing with `file.src || []` eliminates the extra allocation and also correctly handles a null/undefined `file.src` — which the original `.slice()` call would have thrown on.