### PR TITLE
Serve grpc.health.v1.Health on the build session so BuildKit does not drop it

### DIFF
--- a/lib/proto/health.proto
+++ b/lib/proto/health.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/lib/session.js
+++ b/lib/session.js
@@ -51,6 +51,26 @@ function withSession(docker, auth, handler) {
       },
     });
 
+    // BuildKit health-checks the session's gRPC connection (grpc.health.v1.Health/Check)
+    // and tears the session down after a couple of consecutive failed checks
+    // (moby/buildkit session/grpc.go). Without a Health service the check returns
+    // UNIMPLEMENTED, so BuildKit drops the session before the build's first vertex and
+    // the build stalls (typically at "load metadata for <base image>"). Serve SERVING so
+    // the session stays up for the lifetime of the build.
+    const healthPkg = protoLoader.loadSync(
+      path.resolve(__dirname, "proto", "health.proto")
+    );
+    const healthService = grpc.loadPackageDefinition(healthPkg);
+
+    server.addService(healthService.grpc.health.v1.Health.service, {
+      Check(call, callback) {
+        callback(null, { status: "SERVING" });
+      },
+      Watch(call) {
+        call.write({ status: "SERVING" });
+      },
+    });
+
     function done() {
       server.forceShutdown();
       socket.end();


### PR DESCRIPTION
## Problem

BuildKit builds started through `docker.buildImage(..., { version: '2' })` intermittently stall and never produce an image. Under concurrency it becomes the common case. The build hangs at the first vertex, usually `[internal] load metadata for <base image>`, and the daemon logs:

```
level=error msg="healthcheck failed fatally" error="session healthcheck failed fatally: Unimplemented: The server does not implement the method /grpc.health.v1.Health/Check"
...
level=info msg="fetch failed" error="no active session for <uuid>: context canceled"
```

Because the failure names the base image, it is easy to misread as a registry outage or a bad `FROM`, but the registry is never reached.

## Cause

`withSession()` opens the gRPC session BuildKit uses for auth and the build context, and registers the `moby.filesync.v1.Auth` service on it. Recent BuildKit health-checks that session over `grpc.health.v1.Health/Check` and tears the session down after two consecutive failures (see `moby/buildkit` `session/grpc.go`: `interval 5s`, `failureThreshold 2`). Since the session serves no Health service, every check returns `UNIMPLEMENTED`, so BuildKit drops the session ~10s in. A build that clears the session-dependent phase before then succeeds; one that does not stalls, which is why the failure rate rises with the number of in-flight builds.

## Fix

Register a minimal `grpc.health.v1.Health` service on the session that answers `SERVING` for both `Check` and `Watch`. This is what a compliant BuildKit client is expected to provide. No API change; it only adds a service to the session's gRPC server.

Adds `lib/proto/health.proto` (the standard gRPC health protocol) and registers the service in `lib/session.js`, mirroring how the Auth service is loaded and added.

## Verification

Against a rootless Docker Engine 29.6.2 / BuildKit builder that reproduces the drop:

- With an unmodified session, the daemon logs `healthcheck failed fatally: Unimplemented` and then `no active session` for the session's UUID, and the build hangs.
- With this change, holding a session open for 40s (8+ health-check intervals) produces no health-check errors for that UUID, and a `FROM debian:bookworm-slim` + `RUN` build completes end to end in ~13s, past `load metadata`, producing an image.
